### PR TITLE
Create identifier keys when envoys connect

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/etcd/services/EnvoyNodeManagement.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/services/EnvoyNodeManagement.java
@@ -129,6 +129,9 @@ public class EnvoyNodeManagement {
                 buildKey(Keys.FMT_NODES_EXPECTED, nodeKeyHash))
                 .thenCompose(delResponse ->
                         etcd.getKVClient().delete(
-                                buildKey(Keys.FMT_NODES_ACTIVE, nodeKeyHash)));
+                                buildKey(Keys.FMT_NODES_ACTIVE, nodeKeyHash)))
+                .thenCompose(delResponse ->
+                        etcd.getKVClient().delete(
+                                buildKey(Keys.FMT_IDENTIFIERS, tenantId, identifier, identifierValue)));
     }
 }

--- a/src/main/java/com/rackspace/salus/telemetry/etcd/types/Keys.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/types/Keys.java
@@ -39,6 +39,7 @@ public class Keys {
         "/{selectorScope}/{tenant}/{agentConfigId}/{envoyInstanceId}";
     public static final Pattern PTN_APPLIED_CONFIGS = Pattern.compile(
         "/appliedConfigs/(?<scope>.+?)/(?<tenant>.+?)/(?<agentConfigId>.+?)/(?<envoyInstanceId>.+?)");
+    public static final String FMT_IDENTIFIERS = "/tenants/{tenant}/identifiers/{identifier}:{identifierValue}";
     public static final String FMT_NODES_ACTIVE = "/nodes/active/{md5OfTenantAndIdentifierValue}";
     public static final String FMT_NODES_EXPECTED = "/nodes/expected/{md5OfTenantAndIdentifierValue}";
 }

--- a/src/test/java/com/rackspace/salus/telemetry/etcd/services/EnvoyNodeManagementTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/etcd/services/EnvoyNodeManagementTest.java
@@ -132,13 +132,14 @@ public class EnvoyNodeManagementTest {
         verifyNodeInfoPut("/nodes/expected/" + nodeKeyHash, nodeInfo, null);
         verifyIdentifierPut(identifierPath, startedDate);
 
-        when(kv.delete(argThat(t -> t.toStringUtf8().startsWith("/nodes"))))
+        when(kv.delete(argThat(t -> t.toStringUtf8().startsWith("/"))))
                 .thenReturn(completedDeletedResponse());
 
         envoyNodeManagement.removeNode(tenantId, identifier, identifierValue).join();
 
         verifyDelete("/nodes/active/" + nodeKeyHash);
         verifyDelete("/nodes/expected/" + nodeKeyHash);
+        verifyDelete(identifierPath);
     }
 
     private void verifyNodeInfoPut(String k, NodeInfo v, Long leaseId) {

--- a/src/test/java/com/rackspace/salus/telemetry/etcd/services/EnvoyNodeManagementTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/etcd/services/EnvoyNodeManagementTest.java
@@ -22,6 +22,7 @@ import static com.rackspace.salus.telemetry.etcd.EtcdUtils.completedDeletedRespo
 import static com.rackspace.salus.telemetry.etcd.EtcdUtils.completedPutResponse;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
@@ -38,10 +39,12 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
 import com.rackspace.salus.telemetry.etcd.config.KeyHashing;
+import com.rackspace.salus.telemetry.model.NodeConnectionStatus;
 import com.rackspace.salus.telemetry.model.NodeInfo;
 import org.junit.Before;
 import org.junit.Test;
@@ -85,6 +88,7 @@ public class EnvoyNodeManagementTest {
 
     @Test
     public void testRegisterAndRemove() {
+        Date startedDate = new Date();
         Map<String, String> envoyLabels = new HashMap<>();
         envoyLabels.put("os", "LINUX");
         envoyLabels.put("arch", "X86_64");
@@ -113,15 +117,20 @@ public class EnvoyNodeManagementTest {
                 .setTenantId(tenantId)
                 .setAddress(address);
 
-        when(kv.put(argThat(t -> t.toStringUtf8().startsWith("/nodes/expected")), any()))
+        String identifierPath = String.format("/tenants/%s/identifiers/%s:%s",
+                tenantId, identifier, identifierValue);
+
+
+        when(kv.put(argThat(t -> t.toStringUtf8().startsWith("/")), any()))
                 .thenReturn(completedPutResponse());
-        when(kv.put(argThat(t -> t.toStringUtf8().startsWith("/nodes/active")), any(), any()))
+        when(kv.put(argThat(t -> t.toStringUtf8().startsWith("/")), any(), any()))
                 .thenReturn(completedPutResponse());
 
         envoyNodeManagement.registerNode(tenantId, envoyId, leaseId, identifier, envoyLabels, address).join();
 
         verifyNodeInfoPut("/nodes/active/" + nodeKeyHash, nodeInfo, leaseId);
         verifyNodeInfoPut("/nodes/expected/" + nodeKeyHash, nodeInfo, null);
+        verifyIdentifierPut(identifierPath, startedDate);
 
         when(kv.delete(argThat(t -> t.toStringUtf8().startsWith("/nodes"))))
                 .thenReturn(completedDeletedResponse());
@@ -170,7 +179,25 @@ public class EnvoyNodeManagementTest {
         }
     }
 
-    private void verifyDelete(String k) {
+    private void verifyIdentifierPut(String k, Date startedDate) {
+        verify(kv).put(
+                eq(ByteSequence.fromString(k)),
+                argThat(value -> {
+                    byte[] connectionStatusBytes = value.getBytes();
+                    NodeConnectionStatus connectionStatus;
+                    try {
+                        connectionStatus = objectMapper.readValue(connectionStatusBytes, NodeConnectionStatus.class);
+                    } catch (IOException e) {
+                        assertNull(e);
+                        return false;
+                    }
+                    assertTrue(connectionStatus.isConnected());
+                    assertTrue(connectionStatus.getLastConnectedTime().after(startedDate));
+                    return true;
+                }));
+    }
+
+    private void verifyDelete(String k){
         verify(kv).delete(
                 eq(ByteSequence.fromString(k)));
     }


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-73

# What

Creates a new key in redis containing connection status details.

# How

I chose to create it at `/tenants/{tenant}/identifiers/{identifier}:{identifierValue}` rather than `identifiers/{tenantId}/{identifierKey}:{identiferValue}` like the wiki stated.

It is created with no lease.  I am assuming that these keys and the `expected` keys will be tightly coupled together.  Any cleanup performed should remove both of them.  That should only be required when devices go offline or when an identifier is changed for a device.

Uses the new model from https://github.com/racker/salus-telemetry-model/pull/4 as the value stored.

## How to test

Run the `testRegister` test or run an ambassador and connect a new envoy.  You will see this get created in etcd:

```
/tenants/aaaaaa/identifiers/arch:X86_64
{"lastConnectedTime":"2018-12-04T20:59:01.562+0000","connected":true}
```

# Why
From the wiki:

> Enables API queries such as
> GET /api/{tenant}/identifiers
> GET /api/{tenant}/identifiers/{identifierKey}
> GET /api/{tenant}/identifiers/{identifierKey}/{identifierValue}
>
> Response contains at least:
>     Envoy connectivity state

# To Do

`lastConnectedTime` is up for debate as a parameter name.  Maybe `lastAttachmentTime`?  Something that signifies it was the time of the actual attachment and not the last time we saw the envoy... although, as we build out the presence monitoring stuff, we could add those kind of fields.