### PR TITLE
Fix NodeInfo Serialization & Add better tests

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/etcd/services/EnvoyNodeManagement.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/services/EnvoyNodeManagement.java
@@ -32,6 +32,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -78,7 +79,7 @@ public class EnvoyNodeManagement {
                 .setIdentifierValue(identifierValue)
                 .setLabels(envoyLabels)
                 .setTenantId(tenantId)
-                .setAddress(remoteAddr);
+                .setAddress((InetSocketAddress) remoteAddr);
 
         final String nodeKeyHash = hashing.hash(nodeKey);
         final ByteSequence nodeInfoBytes;

--- a/src/test/java/com/rackspace/salus/telemetry/etcd/services/EnvoyNodeManagementTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/etcd/services/EnvoyNodeManagementTest.java
@@ -92,7 +92,7 @@ public class EnvoyNodeManagementTest {
         String identifier = "os";
         String identifierValue = envoyLabels.get(identifier);
         long leaseId = 50;
-        SocketAddress address;
+        InetSocketAddress address;
         try {
             address = new InetSocketAddress(InetAddress.getLocalHost(), 1234);
         } catch (UnknownHostException e) {


### PR DESCRIPTION
Follows on from https://github.com/racker/salus-telemetry-model/pull/5

We cannot use abstract classes so must use `InetSocketAddress` instead.

The extra tests validate that we can deserialize and retrieve the correct values.