### PR TITLE
Add delete node methods

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/etcd/services/EnvoyNodeManagement.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/services/EnvoyNodeManagement.java
@@ -95,4 +95,22 @@ public class EnvoyNodeManagement {
                         etcd.getKVClient().put(
                                 buildKey(Keys.FMT_NODES_ACTIVE, nodeKeyHash), nodeInfoBytes, putLeaseOption));
     }
+
+    /**
+     * Removes all known keys for an envoy from etcd.
+     *
+     * @param tenantId The tenant used to authenticate the the envoy.
+     * @param identifier The key of the label used in envoy presence monitoring.
+     * @param identifierValue The value of the label used in envoy presence monitoring.
+     * @return The results of an etcd DELETE.
+     */
+    public CompletableFuture<?> removeNode(String tenantId, String identifier, String identifierValue) {
+        String nodeKey = String.format("%s:%s:%s", tenantId, identifier, identifierValue);
+        final String nodeKeyHash = hashing.hash(nodeKey);
+        return etcd.getKVClient().delete(
+                buildKey(Keys.FMT_NODES_EXPECTED, nodeKeyHash))
+                .thenCompose(delResponse ->
+                        etcd.getKVClient().delete(
+                                buildKey(Keys.FMT_NODES_ACTIVE, nodeKeyHash)));
+    }
 }


### PR DESCRIPTION
# What

Adds a method to remove nodes from etcd.

# How

Removes both the expected and active keys.  If the active key wasn't removed it'd expire shortly afterwards, but we might as well try and remove everything at the same time to avoid confusing any troubleshooting.

## How to test

Run the test.

# Why

This'll be needed as part of the identifier api.