### PR TITLE
Use etcd client in tests instead of mocks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,13 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>com.github.mxsm</groupId>
+      <artifactId>jetcd-launcher</artifactId>
+      <version>0.3.6</version>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <dependencyManagement>


### PR DESCRIPTION
# What

Uses a real etcd client in tests instead of using the mocks.

# How
Uses jetcd-launcher to spin up an etcd container for use in the tests.

Had to override the properties used in `envoyNodeManagement` via the `TestConfig` class.  This ensure both the test and the register logic are performing operations in the same etcd instance.

The tests now perform an etcd GET to verify the data stored is what we expected.

## How to test

Run the same tests.

Some things that were a bit of a pain... you have to remember to add a `join()` to the etcd GET otherwise it will not bubble up any failures.  Also, (I'm assuming because of the asynchronous nature of the GET) it is not quite as easy to step through the test in debug mode.  You need to add breakpoints within the `thenApply` if you want to debug that section - you will not be able to step into that logic from outside.

# Why

Hopefully to make our tests more trustworthy as it verifies what our application logic has actually done rather than verifying how the mocks have been configured.

# TODO

We may want to apply this logic to the label management tests.  When the time comes, the changes done in here should help with that.