### PR TITLE
Adding a couple more agent config and release operations for public api

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/etcd/lombok.config
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/lombok.config
@@ -1,2 +1,3 @@
 config.stopBubbling = true
+lombok.accessors.chain = true
 lombok.addLombokGeneratedAnnotation = true

--- a/src/main/java/com/rackspace/salus/telemetry/etcd/services/AgentsCatalogService.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/services/AgentsCatalogService.java
@@ -77,9 +77,9 @@ public class AgentsCatalogService {
     public CompletableFuture<AgentRelease> declare(AgentRelease agentRelease) {
         agentRelease.setId(idGenerator.generate());
 
-        final ByteSequence agentInfoBytes;
+        final ByteSequence agentReleaseBytes;
         try {
-            agentInfoBytes = ByteSequence.fromBytes(objectMapper.writeValueAsBytes(agentRelease));
+            agentReleaseBytes = ByteSequence.fromBytes(objectMapper.writeValueAsBytes(agentRelease));
         } catch (JsonProcessingException e) {
             throw new RuntimeException("Failed to marshal AgentInfo", e);
         }
@@ -90,11 +90,11 @@ public class AgentsCatalogService {
                     Keys.FMT_AGENTS_BY_TYPE,
                     agentRelease.getType(), agentRelease.getVersion(), agentRelease.getId()
                 ),
-                agentInfoBytes
+                agentReleaseBytes
             ),
             etcd.getKVClient().put(
                 buildKey("/agentsById/{agentId}", agentRelease.getId()),
-                agentInfoBytes
+                agentReleaseBytes
             )
         )
             .thenApply(aVoid -> agentRelease);
@@ -144,7 +144,7 @@ public class AgentsCatalogService {
                     return objectMapper
                         .readValue(keyValue.getValue().getBytes(), AgentRelease.class);
                   } catch (IOException e) {
-                    log.warn("Failed to parse AgentInfo", e);
+                    log.warn("Failed to parse AgentRelease", e);
                     return null;
                   }
                 })

--- a/src/main/java/com/rackspace/salus/telemetry/etcd/services/AgentsCatalogService.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/services/AgentsCatalogService.java
@@ -41,16 +41,19 @@ import com.rackspace.salus.telemetry.model.AgentRelease;
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.NotFoundException;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 
 @Service
 @Slf4j
@@ -99,6 +102,24 @@ public class AgentsCatalogService {
 
     public CompletableFuture<List<AgentRelease>> getAllAgentReleases() {
         return getAgentReleasesByPrefix(fromString("/agentsByType/"));
+    }
+
+    /**
+     * Provides a query-friendly wrapper around the "getAgentReleases" operations
+     * @return if id is populated, only that agent release. If type is set, only releases of for
+     * that agent type. Otherwise, returns all agent releases.
+     */
+    public CompletableFuture<List<AgentRelease>> queryAgentReleases(@Nullable  String id, @Nullable AgentType type) {
+      if (StringUtils.hasText(id)) {
+        return getAgentById(id)
+            .thenApply(Collections::singletonList);
+      }
+      else if (type != null) {
+        return getAgentReleasesByType(type);
+      }
+      else {
+        return getAllAgentReleases();
+      }
     }
 
     public CompletableFuture<List<AgentRelease>> getAgentReleasesByType(AgentType agentType) {

--- a/src/main/java/com/rackspace/salus/telemetry/etcd/services/AgentsCatalogService.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/services/AgentsCatalogService.java
@@ -179,7 +179,7 @@ public class AgentsCatalogService {
         // to derive agent type
         // put agent install selector
 
-        return getTypeFromAgentInfo(agentInstallSelector.getAgentReleaseId())
+        return getTypeFromAgentRelease(agentInstallSelector.getAgentReleaseId())
             .thenCompose(agentType ->
                 removeOldAgentInstallSelectors(
                     agentInstallSelector, tenantId, agentType))
@@ -291,7 +291,7 @@ public class AgentsCatalogService {
         }
     }
 
-    private CompletableFuture<@NotNull AgentType> getTypeFromAgentInfo(@NotEmpty String agentInfoId) {
+    private CompletableFuture<@NotNull AgentType> getTypeFromAgentRelease(@NotEmpty String agentInfoId) {
         return etcd.getKVClient()
             .get(buildKey("/agentsById/{agentId}", agentInfoId))
             .thenApply(getResponse -> {

--- a/src/main/java/com/rackspace/salus/telemetry/etcd/services/AgentsCatalogService.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/services/AgentsCatalogService.java
@@ -34,9 +34,9 @@ import com.coreos.jetcd.options.GetOption.SortTarget;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.rackspace.salus.telemetry.etcd.EtcdUtils;
+import com.rackspace.salus.telemetry.etcd.types.AgentInstallSelector;
 import com.rackspace.salus.telemetry.etcd.types.KeyedValue;
 import com.rackspace.salus.telemetry.etcd.types.Keys;
-import com.rackspace.salus.telemetry.model.AgentInstallSelector;
 import com.rackspace.salus.telemetry.model.AgentRelease;
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.NotFoundException;
@@ -179,7 +179,7 @@ public class AgentsCatalogService {
         // to derive agent type
         // put agent install selector
 
-        return getTypeFromAgentInfo(agentInstallSelector.getAgentInfoId())
+        return getTypeFromAgentInfo(agentInstallSelector.getAgentReleaseId())
             .thenCompose(agentType ->
                 removeOldAgentInstallSelectors(
                     agentInstallSelector, tenantId, agentType))

--- a/src/main/java/com/rackspace/salus/telemetry/etcd/services/EnvoyLabelManagement.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/services/EnvoyLabelManagement.java
@@ -38,10 +38,10 @@ import com.coreos.jetcd.options.PutOption;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.rackspace.salus.telemetry.etcd.EtcdUtils;
+import com.rackspace.salus.telemetry.etcd.types.AgentInstallSelector;
 import com.rackspace.salus.telemetry.etcd.types.AppliedConfig;
 import com.rackspace.salus.telemetry.etcd.types.Keys;
 import com.rackspace.salus.telemetry.model.AgentConfig;
-import com.rackspace.salus.telemetry.model.AgentInstallSelector;
 import com.rackspace.salus.telemetry.model.AgentType;
 import java.io.IOException;
 import java.util.Collections;
@@ -193,7 +193,7 @@ public class EnvoyLabelManagement {
                                 log.debug("Applying agent install of type={} leaseId={} for tenant={}, envoyInstance={}",
                                     agentType, leaseId, tenantId, envoyInstanceId);
 
-                                final String agentInfoId = agentInstallSelector.getAgentInfoId();
+                                final String agentInfoId = agentInstallSelector.getAgentReleaseId();
 
                                 return installAgentForExistingEnvoy(tenantId, agentType, envoyInstanceId, leaseId, agentInfoId);
                             }))
@@ -413,7 +413,7 @@ public class EnvoyLabelManagement {
             final ByteSequence installKey = buildKey(Keys.FMT_AGENT_INSTALLS,
                 tenantId, envoyInstanceId, agentType);
             final ByteSequence agentInfoIdBytes =
-                ByteSequence.fromString(selectorWithKV.selector.getAgentInfoId());
+                ByteSequence.fromString(selectorWithKV.selector.getAgentReleaseId());
 
             // only install if a more specific match wasn't already processed
             return txn.If(

--- a/src/main/java/com/rackspace/salus/telemetry/etcd/types/AgentInstallSelector.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/types/AgentInstallSelector.java
@@ -1,0 +1,34 @@
+/*
+ *    Copyright 2018 Rackspace US, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *
+ */
+
+package com.rackspace.salus.telemetry.etcd.types;
+
+import java.util.Map;
+import javax.validation.constraints.NotEmpty;
+import lombok.Data;
+
+@Data
+public class AgentInstallSelector {
+    String id;
+
+    @NotEmpty
+    String agentReleaseId;
+
+    @NotEmpty
+    Map<String,String> labels;
+}

--- a/src/main/java/com/rackspace/salus/telemetry/etcd/types/Keys.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/types/Keys.java
@@ -24,11 +24,14 @@ public class Keys {
     public static final String FMT_ENVOYS_BY_ID = "/tenants/{tenant}/envoysById/{envoyInstanceId}";
     public static final String FMT_AGENT_INSTALLS = "/agentInstalls/{tenant}/{envoyInstanceId}/{agentType}";
     public static final Pattern PTN_AGENT_INSTALLS = Pattern.compile("/agentInstalls/(.+?)/(.+?)/(.+?)");
+    public static final String FMT_AGENT_INSTALL_SELECTORS_PREFIX = "/tenants/{tenant}/agentInstallSelectors/";
     public static final String FMT_AGENT_INSTALL_SELECTORS = "/tenants/{tenant}/agentInstallSelectors/{agentType}/{agentInstallSelectorId}";
     public static final Pattern PTN_AGENT_INSTALL_SELECTORS = Pattern.compile(
         "/tenants/(?<tenant>.+?)/agentInstallSelectors/(?<agentType>.+?)/(?<agentInstallSelectorId>.+?)"
     );
     public static final String FMT_ENVOYS_BY_LABEL = "/tenants/{tenant}/envoysByLabel/{name}:{value}/{envoyInstanceId}";
+
+    public static final String FMT_AGENTS_BY_TYPE = "/agentsByType/{agentType}/{version}/{agentId}";
     public static final String FMT_AGENTS_BY_ID = "/agentsById/{agentId}";
 
     public static final String FMT_ENVOYS_BY_AGENT = "/tenants/{tenant}/envoysByAgent/{agentType}/{envoyInstanceId}";

--- a/src/test/java/com/rackspace/salus/telemetry/etcd/services/AgentsCatalogServiceTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/etcd/services/AgentsCatalogServiceTest.java
@@ -39,8 +39,8 @@ import com.coreos.jetcd.options.GetOption;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.protobuf.ByteString;
-import com.rackspace.salus.telemetry.model.AgentInfo;
 import com.rackspace.salus.telemetry.model.AgentInstallSelector;
+import com.rackspace.salus.telemetry.model.AgentRelease;
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.OperatingSystem;
 import java.util.HashMap;
@@ -97,7 +97,7 @@ public class AgentsCatalogServiceTest {
                 return CompletableFuture.completedFuture(invocationOnMock.getArgument(2));
             });
 
-        AgentInfo agentInfo = new AgentInfo()
+        AgentRelease agentRelease = new AgentRelease()
                 .setId("ai1")
                 .setType(AgentType.FILEBEAT);
 
@@ -111,7 +111,7 @@ public class AgentsCatalogServiceTest {
                 .setLabels(labels);
 
         when(kv.get(ByteSequence.fromString("/agentsById/ai1")))
-                .thenReturn(buildGetResponse(objectMapper, "/agentsById/ai1", agentInfo));
+                .thenReturn(buildGetResponse(objectMapper, "/agentsById/ai1", agentRelease));
 
         // prep with no prior selectors
         when(kv.get(eq(ByteSequence.fromString("/tenants/t1/agentInstallSelectors/FILEBEAT")), any(GetOption.class)))

--- a/src/test/java/com/rackspace/salus/telemetry/etcd/services/AgentsCatalogServiceTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/etcd/services/AgentsCatalogServiceTest.java
@@ -39,7 +39,7 @@ import com.coreos.jetcd.options.GetOption;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.protobuf.ByteString;
-import com.rackspace.salus.telemetry.model.AgentInstallSelector;
+import com.rackspace.salus.telemetry.etcd.types.AgentInstallSelector;
 import com.rackspace.salus.telemetry.model.AgentRelease;
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.OperatingSystem;
@@ -107,7 +107,7 @@ public class AgentsCatalogServiceTest {
 
         final AgentInstallSelector selector = new AgentInstallSelector()
                 .setId("ais1")
-                .setAgentInfoId("ai1")
+                .setAgentReleaseId("ai1")
                 .setLabels(labels);
 
         when(kv.get(ByteSequence.fromString("/agentsById/ai1")))
@@ -163,7 +163,7 @@ public class AgentsCatalogServiceTest {
                                                 "/tenants/t1/agentInstallSelectors/FILEBEAT/a"))
                                         .setValue(ByteString.copyFromUtf8("{\n" +
                                                 "  \"id\": \"a\",\n" +
-                                                "  \"agentInfoId\": \"ai1\",\n" +
+                                                "  \"agentReleaseId\": \"ai1\",\n" +
                                                 "  \"labels\": {\n" +
                                                 "    \"os\": \"LINUX\"\n" +
                                                 "  }\n" +
@@ -174,7 +174,7 @@ public class AgentsCatalogServiceTest {
                                                 "/tenants/t1/agentInstallSelectors/FILEBEAT/b"))
                                         .setValue(ByteString.copyFromUtf8("{\n" +
                                                 "  \"id\": \"b\",\n" +
-                                                "  \"agentInfoId\": \"ai2\",\n" +
+                                                "  \"agentReleaseId\": \"ai2\",\n" +
                                                 "  \"labels\": {\n" +
                                                 "    \"os\": \"WINDOWS\"\n" +
                                                 "  }\n" +
@@ -185,7 +185,7 @@ public class AgentsCatalogServiceTest {
                                                 "/tenants/t1/agentInstallSelectors/FILEBEAT/c"))
                                         .setValue(ByteString.copyFromUtf8("{\n" +
                                                 "  \"id\": \"c\",\n" +
-                                                "  \"agentInfoId\": \"ai3\",\n" +
+                                                "  \"agentReleaseId\": \"ai3\",\n" +
                                                 "  \"labels\": {\n" +
                                                 "    \"os\": \"LINUX\"\n" +
                                                 "  }\n" +
@@ -224,7 +224,7 @@ public class AgentsCatalogServiceTest {
                                                 "/tenants/t1/agentInstallSelectors/FILEBEAT/b"))
                                         .setValue(ByteString.copyFromUtf8("{\n" +
                                                 "  \"id\": \"b\",\n" +
-                                                "  \"agentInfoId\": \"ai2\",\n" +
+                                                "  \"agentReleaseId\": \"ai2\",\n" +
                                                 "  \"labels\": {\n" +
                                                 "    \"os\": \"WINDOWS\"\n" +
                                                 "  }\n" +

--- a/src/test/java/com/rackspace/salus/telemetry/etcd/services/ConfigServiceTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/etcd/services/ConfigServiceTest.java
@@ -118,7 +118,7 @@ public class ConfigServiceTest {
         final ByteSequence key = EtcdUtils.buildKey(Keys.FMT_AGENT_CONFIGS, "t1", "");
         when(kv.get(eq(key), any()))
             .thenReturn(buildGetResponse(objectMapper, configKey, agentConfig));
-        List<AgentConfig> results = configService.get("t1").join();
+        List<AgentConfig> results = configService.getAll("t1").join();
         assertEquals(results, Arrays.asList(agentConfig));
 
         // Test modify

--- a/src/test/java/com/rackspace/salus/telemetry/etcd/services/EnvoyLabelManagementTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/etcd/services/EnvoyLabelManagementTest.java
@@ -44,9 +44,9 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.protobuf.ByteString;
 import com.rackspace.salus.telemetry.etcd.EtcdUtils;
+import com.rackspace.salus.telemetry.etcd.types.AgentInstallSelector;
 import com.rackspace.salus.telemetry.etcd.types.AppliedConfig;
 import com.rackspace.salus.telemetry.model.AgentConfig;
-import com.rackspace.salus.telemetry.model.AgentInstallSelector;
 import com.rackspace.salus.telemetry.model.AgentType;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -291,7 +291,7 @@ public class EnvoyLabelManagementTest {
 
         AgentInstallSelector ais = new AgentInstallSelector()
             .setId("ais1")
-            .setAgentInfoId("info1")
+            .setAgentReleaseId("info1")
             .setLabels(selectedLabels);
 
         final AgentInstallSelector result = envoyLabelManagement.applyAgentInfoSelector("t1", AgentType.FILEBEAT, ais).join();
@@ -320,7 +320,7 @@ public class EnvoyLabelManagementTest {
                         )
                         .setValue(ByteString.copyFromUtf8("{\n" +
                             "  \"id\": \"a\",\n" +
-                            "  \"agentInfoId\": \"ai1\",\n" +
+                            "  \"agentReleaseId\": \"ai1\",\n" +
                             "  \"labels\": {\n" +
                             "    \"os\": \"LINUX\"\n" +
                             "  }\n" +
@@ -368,7 +368,7 @@ public class EnvoyLabelManagementTest {
                         )
                         .setValue(ByteString.copyFromUtf8("{\n" +
                             "  \"id\": \"a\",\n" +
-                            "  \"agentInfoId\": \"ai1\",\n" +
+                            "  \"agentReleaseId\": \"ai1\",\n" +
                             "  \"labels\": {\n" +
                             "    \"os\": \"LINUX\"\n" +
                             "  }\n" +


### PR DESCRIPTION
# Resolves

Part of SALUS-81

# What

While converting the public REST API to GraphQL I noticed there were some missing operations since I had skipped them for the POC development.

Also needed to accomodate model rename from https://github.com/racker/salus-telemetry-model/pull/6

## How to test

Standard unit tests

# Why

n/a

# TODO

In a separate PR I will be making changes for the work partitioning API.