### PR TITLE
Add supports for creating/changing work allocation partitions

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/etcd/config/KeyHashing.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/config/KeyHashing.java
@@ -20,9 +20,8 @@ package com.rackspace.salus.telemetry.etcd.config;
 
 import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hashing;
-import org.springframework.stereotype.Component;
-
 import java.nio.charset.StandardCharsets;
+import org.springframework.stereotype.Component;
 
 @Component
 public class KeyHashing {
@@ -39,5 +38,12 @@ public class KeyHashing {
      */
     public String hash(String value) {
         return hashFunction().hashString(value, StandardCharsets.UTF_8).toString();
+    }
+
+    /**
+     * @return the bit size of the current hash algorithm
+     */
+    public int bits() {
+        return hashFunction().bits();
     }
 }

--- a/src/main/java/com/rackspace/salus/telemetry/etcd/services/WorkAllocationPartitionService.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/services/WorkAllocationPartitionService.java
@@ -1,0 +1,111 @@
+package com.rackspace.salus.telemetry.etcd.services;
+
+import static com.rackspace.salus.telemetry.etcd.EtcdUtils.buildKey;
+
+import com.coreos.jetcd.Client;
+import com.coreos.jetcd.data.ByteSequence;
+import com.coreos.jetcd.kv.TxnResponse;
+import com.coreos.jetcd.op.Op;
+import com.coreos.jetcd.options.DeleteOption;
+import com.coreos.jetcd.options.PutOption;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rackspace.salus.telemetry.etcd.config.KeyHashing;
+import com.rackspace.salus.telemetry.etcd.types.KeyRange;
+import com.rackspace.salus.telemetry.etcd.types.Keys;
+import com.rackspace.salus.telemetry.etcd.types.WorkAllocationRealm;
+import java.math.BigInteger;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.util.Assert;
+
+@Service
+@Slf4j
+public class WorkAllocationPartitionService {
+
+  private final Client etcd;
+  private final KeyHashing keyHashing;
+  private final ObjectMapper objectMapper;
+  private final IdGenerator idGenerator;
+
+  @Autowired
+  public WorkAllocationPartitionService(Client etcd, KeyHashing keyHashing,
+      ObjectMapper objectMapper, IdGenerator idGenerator) {
+    this.etcd = etcd;
+    this.keyHashing = keyHashing;
+    this.objectMapper = objectMapper;
+    this.idGenerator = idGenerator;
+  }
+
+  public CompletableFuture<Boolean> changePartitions(WorkAllocationRealm realm, int count) {
+    Assert.isTrue(count > 0, "partition count must be greater than zero");
+
+    final ByteSequence prefix = buildKey(Keys.FMT_WORKALLOC_PARTITIONS, realm, "");
+
+    return etcd.getKVClient()
+        .delete(
+            prefix,
+            DeleteOption.newBuilder()
+                .withPrefix(prefix)
+                .build()
+        )
+        .thenCompose(deleteResponse -> createPartitions(realm, count));
+  }
+
+  private CompletionStage<Boolean> createPartitions(WorkAllocationRealm realm, int count) {
+    final int bits = keyHashing.bits();
+    final BigInteger outerValue = BigInteger.ZERO
+        .setBit(bits);
+
+    final BigInteger[] partitionChunk = outerValue
+        .divideAndRemainder(BigInteger.valueOf(count));
+
+    if (!BigInteger.ZERO.equals(partitionChunk[1])) {
+      throw new IllegalArgumentException(
+          String.format("Hashing bit size %d was not divisible into %d partitions",
+              bits, count
+          ));
+    }
+
+    BigInteger rangeStart = BigInteger.ZERO;
+    final Op[] putOps = new Op[count];
+    for (int i = 0; i < count; i++) {
+      final BigInteger next = rangeStart.add(partitionChunk[0]);
+
+      final KeyRange keyRange = new KeyRange()
+          .setStart(format(rangeStart, bits))
+          .setEnd(format(next.subtract(BigInteger.ONE), bits));
+
+      final ByteSequence key = buildKey(
+          Keys.FMT_WORKALLOC_PARTITIONS, realm, idGenerator.generate());
+      final ByteSequence value;
+      try {
+        value = ByteSequence
+            .fromBytes(objectMapper.writeValueAsBytes(keyRange));
+      } catch (JsonProcessingException e) {
+        log.error("Failed to serialize keyRange={}", keyRange, e);
+        return CompletableFuture.completedFuture(false);
+      }
+
+      putOps[i] = Op.put(key, value, PutOption.DEFAULT);
+
+      rangeStart = next;
+    }
+
+    return etcd.getKVClient().txn().Then(putOps)
+        .commit()
+        .thenApply(TxnResponse::isSucceeded);
+  }
+
+  /**
+   * @return the given value in hex, padded with the appropriate number of leading zeroes for the overall
+   * numeric bit size
+   */
+  private static String format(BigInteger value, int bits) {
+    return String.format("%0"+bits/4+"x", value);
+  }
+
+}

--- a/src/main/java/com/rackspace/salus/telemetry/etcd/types/KeyRange.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/types/KeyRange.java
@@ -1,0 +1,12 @@
+package com.rackspace.salus.telemetry.etcd.types;
+
+import lombok.Data;
+
+@Data
+public class KeyRange {
+  String start;
+  /**
+   * end is inclusive, so usage as an etcd key range-end should append '\0'
+   */
+  String end;
+}

--- a/src/main/java/com/rackspace/salus/telemetry/etcd/types/Keys.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/types/Keys.java
@@ -45,4 +45,6 @@ public class Keys {
     public static final String FMT_IDENTIFIERS = "/tenants/{tenant}/identifiers/{identifier}:{identifierValue}";
     public static final String FMT_NODES_ACTIVE = "/nodes/active/{md5OfTenantAndIdentifierValue}";
     public static final String FMT_NODES_EXPECTED = "/nodes/expected/{md5OfTenantAndIdentifierValue}";
+
+    public static final String FMT_WORKALLOC_PARTITIONS = "/workAllocations/{realm}/partitions/{partitionId}";
 }

--- a/src/main/java/com/rackspace/salus/telemetry/etcd/types/WorkAllocationRealm.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/types/WorkAllocationRealm.java
@@ -1,0 +1,5 @@
+package com.rackspace.salus.telemetry.etcd.types;
+
+public enum WorkAllocationRealm {
+  PRESENCE_MONITOR
+}

--- a/src/test/java/com/rackspace/salus/telemetry/etcd/services/WorkAllocationPartitionServiceTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/etcd/services/WorkAllocationPartitionServiceTest.java
@@ -74,6 +74,23 @@ public class WorkAllocationPartitionServiceTest {
         "8000000000000000000000000000000000000000000000000000000000000000",
         "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
         "2");
+
+    final List<KeyRange> ranges = service.getPartitions(WorkAllocationRealm.PRESENCE_MONITOR)
+        .get();
+
+    assertThat(ranges, hasSize(2));
+    assertEquals(
+        new KeyRange()
+        .setStart("0000000000000000000000000000000000000000000000000000000000000000")
+        .setEnd("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),
+        ranges.get(0)
+    );
+    assertEquals(
+        new KeyRange()
+        .setStart("8000000000000000000000000000000000000000000000000000000000000000")
+        .setEnd("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),
+        ranges.get(1)
+    );
   }
 
   private void assertRangeAt(String expectedStart, String expectedEnd, String id)

--- a/src/test/java/com/rackspace/salus/telemetry/etcd/services/WorkAllocationPartitionServiceTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/etcd/services/WorkAllocationPartitionServiceTest.java
@@ -1,0 +1,100 @@
+package com.rackspace.salus.telemetry.etcd.services;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+import com.coreos.jetcd.Client;
+import com.coreos.jetcd.data.ByteSequence;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rackspace.salus.telemetry.etcd.EtcdUtils;
+import com.rackspace.salus.telemetry.etcd.config.KeyHashing;
+import com.rackspace.salus.telemetry.etcd.types.KeyRange;
+import com.rackspace.salus.telemetry.etcd.types.Keys;
+import com.rackspace.salus.telemetry.etcd.types.WorkAllocationRealm;
+import io.etcd.jetcd.launcher.junit.EtcdClusterResource;
+import java.io.IOException;
+import java.net.URI;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class WorkAllocationPartitionServiceTest {
+
+  @Rule
+  public final EtcdClusterResource etcd = new EtcdClusterResource("WorkAllocationPartitionServiceTest", 1);
+
+  @Mock
+  IdGenerator idGenerator;
+
+  ObjectMapper objectMapper = new ObjectMapper();
+
+  WorkAllocationPartitionService service;
+
+  Client client;
+
+  @Before
+  public void setUp() throws Exception {
+    final List<String> endpoints = etcd.cluster().getClientEndpoints().stream()
+        .map(URI::toString)
+        .collect(Collectors.toList());
+    client = com.coreos.jetcd.Client.builder().endpoints(endpoints).build();
+
+    service = new WorkAllocationPartitionService(
+        client, new KeyHashing(), objectMapper, idGenerator);
+  }
+
+  @Test
+  public void testChangePartitions() throws ExecutionException, InterruptedException {
+
+    final AtomicInteger id = new AtomicInteger(1);
+    when(idGenerator.generate())
+        .then(invocationOnMock -> Integer.toString(id.getAndIncrement()));
+
+    final Boolean result = service.changePartitions(WorkAllocationRealm.PRESENCE_MONITOR, 2)
+        .get();
+
+    assertTrue(result);
+
+    assertRangeAt(
+        "0000000000000000000000000000000000000000000000000000000000000000",
+        "7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        "1");
+    assertRangeAt(
+        "8000000000000000000000000000000000000000000000000000000000000000",
+        "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        "2");
+  }
+
+  private void assertRangeAt(String expectedStart, String expectedEnd, String id)
+      throws ExecutionException, InterruptedException {
+    final ByteSequence key = EtcdUtils
+        .buildKey(Keys.FMT_WORKALLOC_PARTITIONS, WorkAllocationRealm.PRESENCE_MONITOR, id);
+
+    final KeyRange keyRange = client.getKVClient()
+        .get(key)
+        .thenApply(getResponse -> {
+          assertThat(getResponse.getKvs(), hasSize(1));
+
+          try {
+            return objectMapper
+                .readValue(getResponse.getKvs().get(0).getValue().getBytes(), KeyRange.class);
+          } catch (IOException e) {
+            throw new RuntimeException(e);
+          }
+        }).get();
+
+    assertEquals(expectedStart, keyRange.getStart());
+    assertEquals(expectedEnd, keyRange.getEnd());
+  }
+}


### PR DESCRIPTION
# Resolves

Part of SALUS-75

# What

Introduces a new Spring service for creating/changing the work allocation items for the presence monitoring work. Each work item is a `KeyRange` declaring the start and end keys to be watched.

**NOTE**: the `end` key in each range should be appended with a null character (`\0`) to satisfy our expected behavior of the `range_end` semantics:

https://coreos.com/etcd/docs/latest/learning/api.html#key-ranges

# How

Adds the new service and a basic, success path unit test.

## How to test

Usual unit test

# Why

n/a

# TODO

There will be an api PR that will expose the query and mutation operation.