### PR TITLE
Add utility functions for presence monitor

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/etcd/TelemetryCoreEtcdModule.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/TelemetryCoreEtcdModule.java
@@ -23,6 +23,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Profile;
 
 @SpringBootConfiguration
 @ComponentScan
@@ -35,6 +36,8 @@ public class TelemetryCoreEtcdModule {
         this.properties = etcdProperties;
     }
 
+    // This is required to allow mocking of etcd during test programs
+    @Profile("!test")
     @Bean
     public Client etcdClient() {
         return Client.builder().endpoints(properties.getUrl()).build();

--- a/src/main/java/com/rackspace/salus/telemetry/etcd/services/EnvoyResourceManagement.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/services/EnvoyResourceManagement.java
@@ -65,12 +65,12 @@ public class EnvoyResourceManagement {
      *
      * Also creates a key under /tenants/../identifiers with no lease specified.
      *
-     * @param tenantId    The tenant used to authenticate the the envoy.
-     * @param envoyId     The auto-generated unique string associated to the envoy.
-     * @param leaseId     The lease used when creating the /active key.
-     * @param identifier  The key of the label used in envoy presence monitoring.
+     * @param tenantId The tenant used to authenticate the the envoy.
+     * @param envoyId The auto-generated unique string associated to the envoy.
+     * @param leaseId The lease used when creating the /active key.
+     * @param identifier The key of the label used in envoy presence monitoring.
      * @param envoyLabels All labels associated with the envoy.
-     * @param remoteAddr  The address the envoy is connecting from.
+     * @param remoteAddr The address the envoy is connecting from.
      * @return The results of an etcd PUT.
      */
     public CompletableFuture<?> registerResource(String tenantId, String envoyId, long leaseId,
@@ -122,8 +122,8 @@ public class EnvoyResourceManagement {
     /**
      * Removes all known keys for an envoy from etcd.
      *
-     * @param tenantId        The tenant used to authenticate the the envoy.
-     * @param identifier      The key of the label used in envoy presence monitoring.
+     * @param tenantId The tenant used to authenticate the the envoy.
+     * @param identifier The key of the label used in envoy presence monitoring.
      * @param identifierValue The value of the label used in envoy presence monitoring.
      * @return The results of an etcd DELETE.
      */
@@ -140,12 +140,9 @@ public class EnvoyResourceManagement {
                                 buildKey(Keys.FMT_IDENTIFIERS, tenantId, identifier, identifierValue)));
     }
 
-
     public CompletableFuture<GetResponse> getResourcesInRange(String prefix, String min, String max) {
-
         return etcd.getKVClient().get(buildKey(prefix, min),
                 GetOption.newBuilder().withRange(buildKey(prefix, max)).build());
-
     }
 
     public Watch.Watcher getWatchOverRange(String prefix, String min, String max, long revision) {
@@ -154,4 +151,3 @@ public class EnvoyResourceManagement {
                         .withPrevKV(true).withRevision(revision).build());
     }
 }
-

--- a/src/main/java/com/rackspace/salus/telemetry/etcd/services/EnvoyResourceManagement.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/services/EnvoyResourceManagement.java
@@ -142,12 +142,12 @@ public class EnvoyResourceManagement {
 
     public CompletableFuture<GetResponse> getResourcesInRange(String prefix, String min, String max) {
         return etcd.getKVClient().get(buildKey(prefix, min),
-                GetOption.newBuilder().withRange(buildKey(prefix, max)).build());
+                GetOption.newBuilder().withRange(buildKey(prefix, max + '\0')).build());
     }
 
     public Watch.Watcher getWatchOverRange(String prefix, String min, String max, long revision) {
         return etcd.getWatchClient().watch(buildKey(prefix, min),
-                WatchOption.newBuilder().withRange(buildKey(prefix, max))
+                WatchOption.newBuilder().withRange(buildKey(prefix, max + '\0'))
                         .withPrevKV(true).withRevision(revision).build());
     }
 }

--- a/src/main/java/com/rackspace/salus/telemetry/etcd/services/WorkAllocationPartitionService.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/services/WorkAllocationPartitionService.java
@@ -50,7 +50,7 @@ public class WorkAllocationPartitionService {
   public CompletableFuture<Boolean> changePartitions(WorkAllocationRealm realm, int count) {
     Assert.isTrue(count > 0, "partition count must be greater than zero");
 
-    final ByteSequence prefix = buildKey(Keys.FMT_WORKALLOC_PARTITIONS, realm, "");
+    final ByteSequence prefix = buildKey(Keys.FMT_WORKALLOC_REGISTRY, realm, "");
 
     return etcd.getKVClient()
         .delete(
@@ -63,7 +63,7 @@ public class WorkAllocationPartitionService {
   }
 
   public CompletableFuture<List<KeyRange>> getPartitions(WorkAllocationRealm realm) {
-    final ByteSequence prefix = buildKey(Keys.FMT_WORKALLOC_PARTITIONS, realm, "");
+    final ByteSequence prefix = buildKey(Keys.FMT_WORKALLOC_REGISTRY, realm, "");
 
     return etcd.getKVClient()
         .get(
@@ -118,7 +118,7 @@ public class WorkAllocationPartitionService {
           .setEnd(format(next.subtract(BigInteger.ONE), bits));
 
       final ByteSequence key = buildKey(
-          Keys.FMT_WORKALLOC_PARTITIONS, realm, idGenerator.generate());
+          Keys.FMT_WORKALLOC_REGISTRY, realm, idGenerator.generate());
       final ByteSequence value;
       try {
         value = ByteSequence

--- a/src/main/java/com/rackspace/salus/telemetry/etcd/types/EnvoySummary.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/types/EnvoySummary.java
@@ -1,0 +1,37 @@
+/*
+ *    Copyright 2018 Rackspace US, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *
+ */
+
+package com.rackspace.salus.telemetry.etcd.types;
+
+import java.util.List;
+import java.util.Map;
+import javax.validation.constraints.NotEmpty;
+import lombok.Data;
+
+@Data
+public class EnvoySummary {
+    @NotEmpty
+    String version;
+
+    List<String> supportedAgents;
+
+    @NotEmpty
+    Map<String,String> labels;
+
+    String identifier;
+}

--- a/src/main/java/com/rackspace/salus/telemetry/etcd/types/Keys.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/types/Keys.java
@@ -45,5 +45,5 @@ public class Keys {
     public static final String FMT_IDENTIFIERS = "/tenants/{tenant}/identifiers/{identifier}:{identifierValue}";
     public static final String FMT_RESOURCES_ACTIVE = "/resources/active/{md5OfTenantAndIdentifierValue}";
     public static final String FMT_RESOURCES_EXPECTED = "/resources/expected/{md5OfTenantAndIdentifierValue}";
-    public static final String FMT_WORKALLOC_PARTITIONS = "/workAllocations/{realm}/partitions/{partitionId}";
+    public static final String FMT_WORKALLOC_PARTITIONS = "/workAllocations/{realm}/registry/{partitionId}";
 }

--- a/src/main/java/com/rackspace/salus/telemetry/etcd/types/Keys.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/types/Keys.java
@@ -45,5 +45,5 @@ public class Keys {
     public static final String FMT_IDENTIFIERS = "/tenants/{tenant}/identifiers/{identifier}:{identifierValue}";
     public static final String FMT_RESOURCES_ACTIVE = "/resources/active/{md5OfTenantAndIdentifierValue}";
     public static final String FMT_RESOURCES_EXPECTED = "/resources/expected/{md5OfTenantAndIdentifierValue}";
-    public static final String FMT_WORKALLOC_PARTITIONS = "/workAllocations/{realm}/registry/{partitionId}";
+    public static final String FMT_WORKALLOC_REGISTRY = "/workAllocations/{realm}/registry/{partitionId}";
 }

--- a/src/test/java/com/rackspace/salus/telemetry/etcd/services/WorkAllocationPartitionServiceTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/etcd/services/WorkAllocationPartitionServiceTest.java
@@ -96,7 +96,7 @@ public class WorkAllocationPartitionServiceTest {
   private void assertRangeAt(String expectedStart, String expectedEnd, String id)
       throws ExecutionException, InterruptedException {
     final ByteSequence key = EtcdUtils
-        .buildKey(Keys.FMT_WORKALLOC_PARTITIONS, WorkAllocationRealm.PRESENCE_MONITOR, id);
+        .buildKey(Keys.FMT_WORKALLOC_REGISTRY, WorkAllocationRealm.PRESENCE_MONITOR, id);
 
     final KeyRange keyRange = client.getKVClient()
         .get(key)

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,4 @@
+spring:
+  profiles:
+    active:
+      test


### PR DESCRIPTION
# Resolves

part of https://jira.rax.io/browse/SALUS-77

# What

adds a couple of utility functions for the presence monitor

## How to test

presence monitor tests

# Note
this is to be merge to the rebased branch of the partitions api:
https://github.com/racker/salus-telemetry-etcd-adapter/pull/10

