### PR TITLE
Upgrade to Spring Boot 2.1.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,15 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-json</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-logging</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <optional>true</optional>
+    </dependency>
 
     <dependency>
       <groupId>com.rackspace.salus</groupId>
@@ -96,7 +105,7 @@
         <!-- Import dependency management from Spring Boot -->
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
-        <version>2.0.6.RELEASE</version>
+        <version>2.1.2.RELEASE</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/src/test/java/com/rackspace/salus/telemetry/etcd/services/AgentsCatalogServiceTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/etcd/services/AgentsCatalogServiceTest.java
@@ -55,14 +55,11 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.json.JsonTest;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest(webEnvironment = WebEnvironment.NONE)
-@JsonTest // sets up ObjectMapper
+@JsonTest
 public class AgentsCatalogServiceTest {
 
     @MockBean

--- a/src/test/java/com/rackspace/salus/telemetry/etcd/services/ConfigServiceTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/etcd/services/ConfigServiceTest.java
@@ -47,14 +47,11 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.json.JsonTest;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest(webEnvironment = WebEnvironment.NONE)
-@JsonTest // sets up ObjectMapper
+@JsonTest
 public class ConfigServiceTest {
 
     @MockBean

--- a/src/test/java/com/rackspace/salus/telemetry/etcd/services/EnvoyLabelManagementTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/etcd/services/EnvoyLabelManagementTest.java
@@ -65,14 +65,11 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.json.JsonTest;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest(webEnvironment = WebEnvironment.NONE)
-@JsonTest // sets up ObjectMapper
+@JsonTest
 public class EnvoyLabelManagementTest {
 
     @MockBean

--- a/src/test/java/com/rackspace/salus/telemetry/etcd/services/EnvoyLeaseTrackingTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/etcd/services/EnvoyLeaseTrackingTest.java
@@ -40,14 +40,11 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.json.JsonTest;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest(webEnvironment = WebEnvironment.NONE)
-@JsonTest // sets up ObjectMapper
+@JsonTest
 public class EnvoyLeaseTrackingTest {
 
     @MockBean

--- a/src/test/java/com/rackspace/salus/telemetry/etcd/services/EnvoyResourceManagementTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/etcd/services/EnvoyResourceManagementTest.java
@@ -19,13 +19,16 @@
 package com.rackspace.salus.telemetry.etcd.services;
 
 import static com.rackspace.salus.telemetry.etcd.EtcdUtils.buildKey;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import com.coreos.jetcd.Client;
 import com.coreos.jetcd.data.KeyValue;
 import com.coreos.jetcd.lease.LeaseGrantResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
+import com.rackspace.salus.telemetry.etcd.config.KeyHashing;
+import com.rackspace.salus.telemetry.model.ResourceInfo;
+import io.etcd.jetcd.launcher.junit.EtcdClusterResource;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -36,24 +39,18 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
-
-import com.rackspace.salus.telemetry.etcd.config.KeyHashing;
-import com.rackspace.salus.telemetry.model.ResourceInfo;
-import io.etcd.jetcd.launcher.junit.EtcdClusterResource;
-import org.junit.*;
+import org.junit.ClassRule;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.json.JsonTest;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest(webEnvironment = WebEnvironment.NONE)
-@JsonTest // sets up ObjectMapper
+@JsonTest
 public class EnvoyResourceManagementTest {
 
     @Configuration


### PR DESCRIPTION
# Resolves

SALUS-145

# What

Upgrade dependency management from Spring Boot to 2.1.2. 2.1.x is stricter about the unit test app context annotations and could no longer mix the `@JsonTest` with the `@SpringBootTest`, which actually makes sense.

## How to test

Via dependent application unit tests