### PR TITLE
Adding etcd health indicator to assist k8s deployment health

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,20 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~    Copyright 2018 Rackspace US, Inc.
+  ~ Copyright 2019 Rackspace US, Inc.
   ~
-  ~    Licensed under the Apache License, Version 2.0 (the "License");
-  ~    you may not use this file except in compliance with the License.
-  ~    You may obtain a copy of the License at
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
   ~
-  ~        http://www.apache.org/licenses/LICENSE-2.0
+  ~     http://www.apache.org/licenses/LICENSE-2.0
   ~
-  ~    Unless required by applicable law or agreed to in writing, software
-  ~    distributed under the License is distributed on an "AS IS" BASIS,
-  ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~    See the License for the specific language governing permissions and
-  ~    limitations under the License.
-  ~
-  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
@@ -43,6 +41,10 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-logging</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
     </dependency>
 
     <dependency>

--- a/src/main/java/com/rackspace/salus/telemetry/etcd/TelemetryCoreEtcdModule.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/TelemetryCoreEtcdModule.java
@@ -1,25 +1,24 @@
 /*
- *    Copyright 2018 Rackspace US, Inc.
+ * Copyright 2019 Rackspace US, Inc.
  *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- *
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.rackspace.salus.telemetry.etcd;
 
 import com.coreos.jetcd.Client;
 import com.rackspace.salus.common.util.KeyHashing;
+import com.rackspace.salus.telemetry.etcd.services.EtcdHealthIndicator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.context.annotation.Bean;
@@ -46,4 +45,8 @@ public class TelemetryCoreEtcdModule {
         return Client.builder().endpoints(properties.getUrl()).build();
     }
 
+    @Bean
+    public EtcdHealthIndicator etcdHealthIndicator() {
+        return new EtcdHealthIndicator(etcdClient());
+    }
 }

--- a/src/main/java/com/rackspace/salus/telemetry/etcd/services/EtcdHealthIndicator.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/services/EtcdHealthIndicator.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.etcd.services;
+
+import com.coreos.jetcd.Client;
+import com.coreos.jetcd.data.ByteSequence;
+import com.coreos.jetcd.kv.GetResponse;
+import java.util.concurrent.ExecutionException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+
+/**
+ * Provides a Spring Boot actuator health indicator that determines the health of etcd by
+ * performing a retrieval of an arbitrary key ("/"). Etcd is deemed healthy when that key
+ * retrieval completes without an exception.
+ */
+public class EtcdHealthIndicator implements HealthIndicator {
+
+  private final Client etcd;
+
+  @Autowired
+  public EtcdHealthIndicator(Client etcd) {
+    this.etcd = etcd;
+  }
+
+  @Override
+  public Health health() {
+    try {
+      final GetResponse resp = etcd.getKVClient().get(ByteSequence.fromString("/"))
+          .get();
+      return Health.up().build();
+    } catch (InterruptedException | ExecutionException e) {
+      return Health.down(e).build();
+    }
+  }
+}


### PR DESCRIPTION
# Resolves

Helps SALUS-93

# What

Adds an etcd health indicator so that k8s pod health checks using the {{/actuator/health}} endpoint will also be confirming etcd connectivity.

## How to test

I tested manually by bringing up the ambassador app with the etcd container already running. Then I stopped etcd and hit the health endpoint again. Lastly, I started the container again and confirmed health went back to UP.

```
➜  ~ curl localhost:8081/actuator/health
{"status":"UP"}%                                                                                                                                      ➜  ~ curl localhost:8081/actuator/health
{"status":"UP","details":{"etcd":{"status":"UP"},"diskSpace":{"status":"UP","details":{"total":250140434432,"free":35397124096,"threshold":10485760}}}}%                                                                                                                                                    

➜  ~ curl localhost:8081/actuator/health
{"status":"DOWN","details":{"etcd":{"status":"DOWN","details":{"error":"java.util.concurrent.ExecutionException: java.util.concurrent.ExecutionException: io.grpc.StatusRuntimeException: UNAVAILABLE: io exception"}},"diskSpace":{"status":"UP","details":{"total":250140434432,"free":35399811072,"threshold":10485760}}}}%                                                                                                                                    

➜  ~ curl localhost:8081/actuator/health
{"status":"UP","details":{"etcd":{"status":"UP"},"diskSpace":{"status":"UP","details":{"total":250140434432,"free":35403960320,"threshold":10485760}}}}%                                                                                                                                                    
```