### PR TITLE
Support remote polling with zone storage

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -29,7 +29,7 @@ steps:
 
   - id: DEPLOY
     name: 'gcr.io/cloud-builders/mvn'
-    args: ['deploy', '-s', '.mvn/settings.xml']
+    args: ['-B', 'deploy', '-s', '.mvn/settings.xml']
     volumes:
     - name: user.home
       path: /root

--- a/src/main/java/com/rackspace/salus/telemetry/etcd/EtcdUtils.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/EtcdUtils.java
@@ -168,5 +168,16 @@ public class EtcdUtils {
         );
     }
 
-
+    /**
+     * Ensures the given value is safe to use as part of a key path by doing simple encoding
+     * like HTML URL encoding to replace slashes.
+     * @param value the raw value
+     * @return the escaped version of the given value
+     */
+    public static String escapePathPart(String value) {
+        if (value == null) {
+            return null;
+        }
+        return value.replace("/", "%2F");
+    }
 }

--- a/src/main/java/com/rackspace/salus/telemetry/etcd/TelemetryCoreEtcdModule.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/TelemetryCoreEtcdModule.java
@@ -24,7 +24,6 @@ import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Import;
-import org.springframework.context.annotation.Profile;
 
 @SpringBootConfiguration
 @ComponentScan
@@ -38,8 +37,6 @@ public class TelemetryCoreEtcdModule {
         this.properties = etcdProperties;
     }
 
-    // This is required to allow mocking of etcd during test programs
-    @Profile("!test")
     @Bean
     public Client etcdClient() {
         return Client.builder().endpoints(properties.getUrl()).build();

--- a/src/main/java/com/rackspace/salus/telemetry/etcd/services/EnvoyResourceManagement.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/services/EnvoyResourceManagement.java
@@ -141,12 +141,12 @@ public class EnvoyResourceManagement {
                 }));
     }
 
-    public CompletableFuture<List<ResourceInfo>> getOne(String tenantId, String resourceId) {
+    public CompletableFuture<ResourceInfo> getOne(String tenantId, String resourceId) {
         ByteSequence key = EtcdUtils.buildKey(Keys.FMT_IDENTIFIERS, tenantId, resourceId);
         return etcd.getKVClient().get(key)
                 .thenApply(getResponse -> {
                     log.debug("Found {} resources for tenant {} with resourceId {}", getResponse.getKvs().size(), tenantId, resourceId);
-                    return parseResourceInfo(getResponse.getKvs());
+                    return parseResourceInfo(getResponse.getKvs()).get(0);
                 });
     }
 

--- a/src/main/java/com/rackspace/salus/telemetry/etcd/services/ZoneStorage.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/services/ZoneStorage.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.etcd.services;
+
+import static com.rackspace.salus.telemetry.etcd.EtcdUtils.buildKey;
+import static com.rackspace.salus.telemetry.etcd.types.Keys.FMT_ZONE_ACTIVE;
+import static com.rackspace.salus.telemetry.etcd.types.Keys.FMT_ZONE_EXPECTED;
+
+import com.coreos.jetcd.Client;
+import com.coreos.jetcd.KV;
+import com.coreos.jetcd.data.ByteSequence;
+import com.coreos.jetcd.data.KeyValue;
+import com.coreos.jetcd.op.Cmp;
+import com.coreos.jetcd.op.CmpTarget;
+import com.coreos.jetcd.op.Op;
+import com.coreos.jetcd.options.GetOption;
+import com.coreos.jetcd.options.GetOption.SortOrder;
+import com.coreos.jetcd.options.GetOption.SortTarget;
+import com.coreos.jetcd.options.PutOption;
+import com.rackspace.salus.telemetry.etcd.types.EtcdStorageException;
+import com.rackspace.salus.telemetry.etcd.types.ResolvedZone;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+public class ZoneStorage {
+
+  private static final String FMT_BOUND_COUNT = "%010d";
+
+  private final Client etcd;
+
+  @Autowired
+  public ZoneStorage(Client etcd) {
+    this.etcd = etcd;
+  }
+
+  @SuppressWarnings("UnstableApiUsage")
+  public CompletableFuture<?> registerEnvoyInZone(ResolvedZone zone, String envoyId,
+                                                  String resourceId, long envoyLeaseId) throws EtcdStorageException {
+    log.debug("Registering envoy={} with resourceId={} in zone={}",
+        envoyId, resourceId, zone);
+
+    final KV kv = etcd.getKVClient();
+
+    return CompletableFuture.allOf(
+        kv.put(
+            buildKey(FMT_ZONE_ACTIVE, zone.getTenantForKey(), zone.getZoneIdForKey(), envoyId),
+            ByteSequence.fromString(String.format(FMT_BOUND_COUNT, 0)),
+            PutOption.newBuilder()
+                .withLeaseId(envoyLeaseId)
+                .build()
+        ),
+        kv.put(
+            buildKey(FMT_ZONE_EXPECTED, zone.getTenantForKey(), zone.getZoneIdForKey(), resourceId),
+            ByteSequence.fromString(envoyId),
+            PutOption.DEFAULT
+        )
+    );
+  }
+
+  public CompletableFuture<Integer> incrementBoundCount(ResolvedZone zone, String envoyId) {
+    log.debug("Incrementing bound count of envoy={} in zone={}", envoyId, zone);
+
+    final ByteSequence key = buildKey(
+        FMT_ZONE_ACTIVE, zone.getTenantForKey(), zone.getZoneIdForKey(), envoyId);
+
+    return etcd.getKVClient().get(key)
+        .thenCompose(getResponse -> {
+
+          if (getResponse.getKvs().isEmpty()) {
+            throw new EtcdStorageException(
+                String.format("Expected key not present: %s", key.toStringUtf8()));
+          }
+
+          final KeyValue kvEntry = getResponse.getKvs().get(0);
+          final int prevCount = Integer.parseInt(kvEntry.getValue().toStringUtf8(), 10);
+          final int newCount = prevCount + 1;
+
+          log.debug("Putting new bound count={} for envoy={} in zone={}", newCount, envoyId, zone);
+
+          final ByteSequence newValue = ByteSequence.fromString(String.format(FMT_BOUND_COUNT,
+              newCount
+          ));
+
+          return etcd.getKVClient().txn()
+              .If(
+                  new Cmp(key, Cmp.Op.EQUAL, CmpTarget.version(kvEntry.getVersion()))
+              )
+              .Then(
+                  Op.put(
+                      key,
+                      newValue,
+                      PutOption.newBuilder()
+                          .withLeaseId(kvEntry.getLease())
+                          .build()
+                  )
+              )
+              .commit()
+              .thenCompose(txnResponse -> {
+
+                if (txnResponse.isSucceeded()) {
+                  return CompletableFuture.completedFuture(newCount);
+                }
+                else {
+                  log.debug("Re-trying incrementing bound count of envoy={} in zone={} due to collision",
+                      envoyId, zone);
+                  return incrementBoundCount(zone, envoyId);
+                }
+
+              });
+        });
+  }
+
+  public CompletableFuture<Optional<String>> findLeastLoadedEnvoy(ResolvedZone zone) {
+    final ByteSequence prefix =
+        buildKey(FMT_ZONE_ACTIVE, zone.getTenantForKey(), zone.getZoneIdForKey(), "");
+
+    return etcd.getKVClient().get(
+        prefix,
+        GetOption.newBuilder()
+            .withPrefix(prefix)
+            .withSortField(SortTarget.VALUE)
+            .withSortOrder(SortOrder.ASCEND)
+            .withLimit(1)
+            .build()
+    )
+        .thenApply(getResponse -> {
+          if (getResponse.getKvs().isEmpty()) {
+            return Optional.empty();
+          } else {
+            final String envoyKeyInZone = getResponse.getKvs().get(0).getKey().toStringUtf8();
+
+            return Optional.of(
+                envoyKeyInZone.substring(envoyKeyInZone.lastIndexOf("/") + 1)
+            );
+
+          }
+        });
+  }
+}

--- a/src/main/java/com/rackspace/salus/telemetry/etcd/types/EtcdStorageException.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/types/EtcdStorageException.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.etcd.types;
+
+/**
+ * Indicates that some kind of issue occurred while performing an etcd storage operation that
+ * might vary from serialization issues to backend etcd issues.
+ */
+public class EtcdStorageException extends RuntimeException {
+
+  public EtcdStorageException(String message) {
+    super(message);
+  }
+
+  public EtcdStorageException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/src/main/java/com/rackspace/salus/telemetry/etcd/types/Keys.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/types/Keys.java
@@ -45,5 +45,8 @@ public class Keys {
      * Value is count of bound monitors, leading zero padded to 10 digits
      */
     public static final String FMT_ZONE_ACTIVE = "/zones/active/{tenant}/{zoneId}/{pollerEnvoyId}";
+    /**
+     * Value is latest attached envoy ID
+     */
     public static final String FMT_ZONE_EXPECTED = "/zones/expected/{tenant}/{zoneId}/{resourceId}";
 }

--- a/src/main/java/com/rackspace/salus/telemetry/etcd/types/Keys.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/types/Keys.java
@@ -40,4 +40,10 @@ public class Keys {
     public static final String FMT_IDENTIFIERS_BY_IDENTIFIER = "/tenants/{tenant}/identifiers/{identifierName}";
     public static final String FMT_RESOURCES_ACTIVE = "/resources/active/{md5OfTenantAndIdentifierValue}";
     public static final String FMT_WORKALLOC_REGISTRY = "/workAllocations/{realm}/registry/{partitionId}";
+
+    /**
+     * Value is count of bound monitors, leading zero padded to 10 digits
+     */
+    public static final String FMT_ZONE_ACTIVE = "/zones/active/{tenant}/{zoneId}/{pollerEnvoyId}";
+    public static final String FMT_ZONE_EXPECTED = "/zones/expected/{tenant}/{zoneId}/{resourceId}";
 }

--- a/src/main/java/com/rackspace/salus/telemetry/etcd/types/ResolvedZone.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/types/ResolvedZone.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.etcd.types;
+
+import com.rackspace.salus.telemetry.etcd.EtcdUtils;
+import lombok.Data;
+
+@Data
+public class ResolvedZone {
+
+  public static final String PUBLIC = "_PUBLIC_";
+
+  String id;
+  String tenantId;
+  boolean publicZone;
+
+  public String getTenantId() {
+    return publicZone ? null : tenantId;
+  }
+
+  public String getTenantForKey() {
+    if (publicZone) {
+      return PUBLIC;
+    }
+    else {
+      return tenantId;
+    }
+  }
+
+  public String getZoneIdForKey() {
+    return EtcdUtils.escapePathPart(id);
+  }
+}

--- a/src/test/java/com/rackspace/salus/telemetry/etcd/EtcdUtilsTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/etcd/EtcdUtilsTest.java
@@ -20,13 +20,18 @@ package com.rackspace.salus.telemetry.etcd;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import com.coreos.jetcd.data.ByteSequence;
+import com.coreos.jetcd.options.PutOption;
 import com.rackspace.salus.telemetry.model.AgentType;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import org.junit.Test;
+import org.mockito.ArgumentMatcher;
+import org.mockito.ArgumentMatchers;
 
 public class EtcdUtilsTest {
 
@@ -114,5 +119,83 @@ public class EtcdUtilsTest {
         final boolean result = EtcdUtils.mapContainsAll(superset, target);
 
         assertTrue(result);
+    }
+
+    @Test
+    public void testEscapePathPart_withSlash() {
+        final String result = EtcdUtils.escapePathPart("one/two");
+
+        assertEquals("one%2Ftwo", result);
+    }
+
+    @Test
+    public void testEscapePathPart_withMultipleSlashes() {
+        final String result = EtcdUtils.escapePathPart("one/two/three");
+
+        assertEquals("one%2Ftwo%2Fthree", result);
+    }
+
+    @Test
+    public void testEscapePathPart_withoutSlash() {
+        final String result = EtcdUtils.escapePathPart("one-two");
+
+        assertEquals("one-two", result);
+    }
+
+    @SuppressWarnings("ConstantConditions")
+    @Test
+    public void testEscapePathPart_null() {
+        final String result = EtcdUtils.escapePathPart(null);
+
+        assertNull(result);
+    }
+
+    public static ByteSequence equalsByteSequence(String str) {
+        return ArgumentMatchers.argThat(new ByteSequenceEquals(ByteSequence.fromString(str)));
+    }
+
+    public static ByteSequence equalsByteSequence(ByteSequence expected) {
+        return ArgumentMatchers.argThat(new ByteSequenceEquals(expected));
+    }
+
+    static class ByteSequenceEquals implements ArgumentMatcher<ByteSequence> {
+        private final ByteSequence expected;
+
+        ByteSequenceEquals(ByteSequence expected) {
+            this.expected = expected;
+        }
+
+        @Override
+        public boolean matches(ByteSequence actual) {
+            return Objects.equals(expected, actual);
+        }
+
+        @Override
+        public String toString() {
+            return String.format("[ByteSequence of '%s']", expected.toStringUtf8());
+        }
+    }
+
+    public static PutOption putOptionWithLease(long lease) {
+        return ArgumentMatchers.argThat(new PutOptionWithLease(lease));
+    }
+
+    static class PutOptionWithLease implements ArgumentMatcher<PutOption> {
+
+        private final long lease;
+
+        PutOptionWithLease(long lease) {
+            this.lease = lease;
+        }
+
+        @Override
+        public boolean matches(PutOption actual) {
+            return actual.getLeaseId() == lease;
+        }
+
+        @Override
+        public String toString() {
+            return String.format("[PutOption with leaseId=%d]", lease);
+        }
     }
 }

--- a/src/test/java/com/rackspace/salus/telemetry/etcd/services/WorkAllocationPartitionServiceTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/etcd/services/WorkAllocationPartitionServiceTest.java
@@ -9,8 +9,8 @@ import static org.mockito.Mockito.when;
 import com.coreos.jetcd.Client;
 import com.coreos.jetcd.data.ByteSequence;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.rackspace.salus.telemetry.etcd.EtcdUtils;
 import com.rackspace.salus.common.util.KeyHashing;
+import com.rackspace.salus.telemetry.etcd.EtcdUtils;
 import com.rackspace.salus.telemetry.etcd.types.KeyRange;
 import com.rackspace.salus.telemetry.etcd.types.Keys;
 import com.rackspace.salus.telemetry.etcd.types.WorkAllocationRealm;
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -52,6 +53,11 @@ public class WorkAllocationPartitionServiceTest {
 
     service = new WorkAllocationPartitionService(
         client, new KeyHashing(), objectMapper, idGenerator);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    client.close();
   }
 
   @Test

--- a/src/test/java/com/rackspace/salus/telemetry/etcd/services/ZoneStorageTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/etcd/services/ZoneStorageTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.etcd.services;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertThat;
+
+import com.coreos.jetcd.Client;
+import com.coreos.jetcd.data.ByteSequence;
+import com.coreos.jetcd.kv.GetResponse;
+import com.coreos.jetcd.lease.LeaseGrantResponse;
+import com.rackspace.salus.telemetry.etcd.types.ResolvedZone;
+import io.etcd.jetcd.launcher.junit.EtcdClusterResource;
+import java.net.URI;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class ZoneStorageTest {
+  @Rule
+  public final EtcdClusterResource etcd = new EtcdClusterResource("ZoneStorageTest", 1);
+
+  private Client client;
+
+  private ZoneStorage zoneStorage;
+
+  @Before
+  public void setUp() {
+    final List<String> endpoints = etcd.cluster().getClientEndpoints().stream()
+        .map(URI::toString)
+        .collect(Collectors.toList());
+    client = com.coreos.jetcd.Client.builder().endpoints(endpoints).build();
+
+    zoneStorage = new ZoneStorage(client);
+  }
+
+  @After
+  public void tearDown() {
+    client.close();
+  }
+
+  @Test
+  public void testRegisterEnvoy() {
+
+    final long leaseId = grantLease();
+
+    ResolvedZone zone = new ResolvedZone()
+        .setId("zone-1")
+        .setTenantId("t-1");
+    zoneStorage.registerEnvoyInZone(zone, "123-456", "r-1", leaseId).join();
+
+    final GetResponse activeResponse = client.getKVClient()
+        .get(ByteSequence.fromString("/zones/active/t-1/zone-1/123-456"))
+        .join();
+    assertThat(activeResponse.getKvs(), hasSize(1));
+    assertThat(activeResponse.getKvs().get(0).getLease(), equalTo(leaseId));
+    assertThat(activeResponse.getKvs().get(0).getValue().toStringUtf8(), equalTo("0000000000"));
+
+    final GetResponse expectedResponse = client.getKVClient()
+        .get(ByteSequence.fromString("/zones/expected/t-1/zone-1/r-1"))
+        .join();
+    assertThat(expectedResponse.getKvs(), hasSize(1));
+    assertThat(expectedResponse.getKvs().get(0).getLease(), equalTo(0L));
+    assertThat(expectedResponse.getKvs().get(0).getValue().toStringUtf8(), equalTo("123-456"));
+  }
+
+  @Test
+  public void testUpdateBound_and_leastLoaded() {
+    // just use one lease for all three
+    final long leaseId = grantLease();
+
+    ResolvedZone zone = new ResolvedZone()
+        .setId("zone-1")
+        .setTenantId("t-1");
+
+    zoneStorage.registerEnvoyInZone(zone, "e-1", "r-1", leaseId).join();
+    zoneStorage.registerEnvoyInZone(zone, "e-2", "r-2", leaseId).join();
+    zoneStorage.registerEnvoyInZone(zone, "e-3", "r-3", leaseId).join();
+
+    for (int i = 0; i < 10; ++i) {
+      zoneStorage.incrementBoundCount(zone, "e-1")
+      .join();
+    }
+    for (int i = 0; i < 20; ++i) {
+      zoneStorage.incrementBoundCount(zone, "e-2")
+      .join();
+    }
+    for (int i = 0; i < 5; ++i) {
+      zoneStorage.incrementBoundCount(zone, "e-3")
+      .join();
+    }
+
+    assertValueAndLease("/zones/active/t-1/zone-1/e-1", 10, leaseId);
+    assertValueAndLease("/zones/active/t-1/zone-1/e-2", 20, leaseId);
+    assertValueAndLease("/zones/active/t-1/zone-1/e-3", 5, leaseId);
+
+    final Optional<String> leastLoaded = zoneStorage.findLeastLoadedEnvoy(zone).join();
+    assertThat(leastLoaded.isPresent(), equalTo(true));
+    //noinspection OptionalGetWithoutIsPresent
+    assertThat(leastLoaded.get(), equalTo("e-3"));
+  }
+
+  @Test
+  public void testLeastLoaded_emptyZone() {
+    ResolvedZone zone = new ResolvedZone()
+        .setId("zone-nowhere")
+        .setTenantId("t-none");
+
+    final Optional<String> leastLoaded = zoneStorage.findLeastLoadedEnvoy(zone).join();
+    assertThat(leastLoaded.isPresent(), equalTo(false));
+  }
+
+  private void assertValueAndLease(String key, int expectedCount, long leaseId) {
+    final GetResponse getResponse = client.getKVClient().get(
+        ByteSequence.fromString(key)
+    ).join();
+
+    assertThat(getResponse.getKvs(), hasSize(1));
+    assertThat(getResponse.getKvs().get(0).getValue().toStringUtf8(), equalTo(String.format("%010d", expectedCount)));
+    assertThat(getResponse.getKvs().get(0).getLease(), equalTo(leaseId));
+  }
+
+  private long grantLease() {
+    final LeaseGrantResponse leaseGrant = client.getLeaseClient().grant(10000).join();
+    final long leaseId = leaseGrant.getID();
+    client.getLeaseClient().keepAlive(leaseId);
+    return leaseId;
+  }
+}

--- a/src/test/java/com/rackspace/salus/telemetry/etcd/types/ResolvedZoneTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/etcd/types/ResolvedZoneTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.etcd.types;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+public class ResolvedZoneTest {
+
+  @Test
+  public void getTenantForKey_nonPublic() {
+    final ResolvedZone zone = new ResolvedZone()
+        .setPublicZone(false)
+        .setTenantId("tenant-1");
+
+    assertThat(zone.getTenantForKey(), equalTo("tenant-1"));
+  }
+
+  @Test
+  public void getTenantForKey_public() {
+    final ResolvedZone zone = new ResolvedZone()
+        .setPublicZone(true)
+        .setTenantId("tenant-1");
+
+    assertThat(zone.getTenantForKey(), equalTo(ResolvedZone.PUBLIC));
+  }
+
+  @Test
+  public void getTenantAlwaysNullForPublic() {
+    final ResolvedZone zone = new ResolvedZone()
+        .setPublicZone(true)
+        .setTenantId("tenant-1");
+
+    assertThat(zone.getTenantId(), nullValue());
+  }
+
+  @Test
+  public void getZoneIdForKey() {
+    final ResolvedZone zone = new ResolvedZone()
+        .setId("companyName/west")
+        .setPublicZone(true)
+        .setTenantId("tenant-1");
+
+    assertThat(zone.getZoneIdForKey(), equalTo("companyName%2Fwest"));
+  }
+}


### PR DESCRIPTION
# Resolves

Part of
- https://jira.rax.io/browse/SALUS-292
- https://jira.rax.io/browse/SALUS-305

# What

Mainly introduces `ZoneStorage`, which is kind of a like a repository in JPA. It, along with the new `ResolveZone` model-utility-class, coordinate tracking envoys and resources in zones and the querying of zones to find the least loaded envoy. FYI, there will likely be more refinements and changes in this area as we progress through more of remote polling scenarios.

## How to test

Unit tests have been added and extended