### PR TITLE
Add support for zone watching in ZoneStorage

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/etcd/EtcdUtils.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/EtcdUtils.java
@@ -36,6 +36,10 @@ import java.util.function.BinaryOperator;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+/**
+ * This class contains various utility methods that simplify tedious code needed
+ * for interacting with etcd.
+ */
 public class EtcdUtils {
 
     private static final Pattern KEY_PLACEHOLDER = Pattern.compile("\\{.+?\\}");
@@ -77,6 +81,22 @@ public class EtcdUtils {
         return ByteSequence.fromString(sb.toString());
     }
 
+    /**
+     * This method converts a format string with <code>{...}</code> placeholders into a 
+     * regex pattern with capture groups named for each format placeholder.
+     * <p>
+     *   For example, given the format string
+     *   <pre>
+     *     /zones/expected/{tenant}/{zoneId}/{resourceId}
+     *   </pre>
+     *   then this method will produce a regex pattern:
+     *   <pre>
+     *     /zones/expected/(?&lt;tenant&gt;.+?)/(?&lt;zoneId&gt;.+?)/(?&lt;resourceId&gt;.+?)
+     *   </pre>
+     * </p>
+     * @param format a <code>{...}</code> format string
+     * @return a regex pattern that can parse the given <code>format</code>
+     */
     public static Pattern patternFromFormat(String format) {
         final Pattern placeholders = Pattern.compile("\\{(.+?)}");
 

--- a/src/main/java/com/rackspace/salus/telemetry/etcd/EtcdUtils.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/EtcdUtils.java
@@ -77,6 +77,19 @@ public class EtcdUtils {
         return ByteSequence.fromString(sb.toString());
     }
 
+    public static Pattern patternFromFormat(String format) {
+        final Pattern placeholders = Pattern.compile("\\{(.+?)}");
+
+        final Matcher matcher = placeholders.matcher(format);
+        StringBuffer sb = new StringBuffer();
+        while (matcher.find()) {
+            matcher.appendReplacement(sb, String.format("(?<%s>.+?)", matcher.group(1)));
+        }
+        matcher.appendTail(sb);
+
+        return Pattern.compile(sb.toString());
+    }
+
     public static ByteString buildByteString(String format, Object... values) {
         return ByteString.copyFromUtf8(
                 String.format(format, values)
@@ -179,5 +192,17 @@ public class EtcdUtils {
             return null;
         }
         return value.replace("/", "%2F");
+    }
+
+    /**
+     * Reverses the processing of {@link #escapePathPart(String)}
+     * @param rawValue the part of an etcd key that has been escaped by {@link #escapePathPart(String)}
+     * @return the unescaped value
+     */
+    public static String unescapePathPart(String rawValue) {
+        if (rawValue == null) {
+            return rawValue;
+        }
+        return rawValue.replace("%2F", "/");
     }
 }

--- a/src/main/java/com/rackspace/salus/telemetry/etcd/services/EnvoyResourceManagement.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/services/EnvoyResourceManagement.java
@@ -146,31 +146,12 @@ public class EnvoyResourceManagement {
         return etcd.getKVClient().get(key)
                 .thenApply(getResponse -> {
                     log.debug("Found {} resources for tenant {} with resourceId {}", getResponse.getKvs().size(), tenantId, resourceId);
+                  if (getResponse.getKvs().isEmpty()) {
+                    return null;
+                  }
+                  else {
                     return parseResourceInfo(getResponse.getKvs()).get(0);
-                });
-    }
-
-    public CompletableFuture<List<ResourceInfo>> getSome(String tenantId, String identifierName) {
-        ByteSequence key = EtcdUtils.buildKey(Keys.FMT_IDENTIFIERS_BY_IDENTIFIER, tenantId, identifierName);
-        return etcd.getKVClient().get(key,
-                GetOption.newBuilder()
-                        .withPrefix(key)
-                        .build())
-                .thenApply(getResponse -> {
-                    log.debug("Found {} resources for tenant {} with identifierName {}", getResponse.getKvs().size(), tenantId, identifierName);
-                    return parseResourceInfo(getResponse.getKvs());
-                });
-    }
-
-    public CompletableFuture<List<ResourceInfo>> getAll(String tenantId) {
-        ByteSequence key = EtcdUtils.buildKey(Keys.FMT_IDENTIFIERS_BY_TENANT, tenantId);
-        return etcd.getKVClient().get(key,
-                GetOption.newBuilder()
-                        .withPrefix(key)
-                        .build())
-                .thenApply(getResponse -> {
-                    log.debug("Found {} resources for tenant {}", getResponse.getKvs().size(), tenantId);
-                    return parseResourceInfo(getResponse.getKvs());
+                  }
                 });
     }
 

--- a/src/main/java/com/rackspace/salus/telemetry/etcd/services/ZoneStorage.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/services/ZoneStorage.java
@@ -154,6 +154,8 @@ public class ZoneStorage {
   }
 
   public CompletableFuture<Optional<String>> findLeastLoadedEnvoy(ResolvedZone zone) {
+    log.debug("Finding least loaded envoy in zone={}", zone);
+
     final ByteSequence prefix =
         buildKey(FMT_ZONE_ACTIVE, zone.getTenantForKey(), zone.getZoneIdForKey(), "");
 

--- a/src/main/java/com/rackspace/salus/telemetry/etcd/services/ZoneStorage.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/services/ZoneStorage.java
@@ -17,11 +17,17 @@
 package com.rackspace.salus.telemetry.etcd.services;
 
 import static com.rackspace.salus.telemetry.etcd.EtcdUtils.buildKey;
+import static com.rackspace.salus.telemetry.etcd.types.Keys.DELIMITER;
 import static com.rackspace.salus.telemetry.etcd.types.Keys.FMT_ZONE_ACTIVE;
 import static com.rackspace.salus.telemetry.etcd.types.Keys.FMT_ZONE_EXPECTED;
+import static com.rackspace.salus.telemetry.etcd.types.Keys.PREFIX_ZONE_EXPECTED;
+import static com.rackspace.salus.telemetry.etcd.types.Keys.PTN_ZONE_EXPECTED;
 
 import com.coreos.jetcd.Client;
 import com.coreos.jetcd.KV;
+import com.coreos.jetcd.Watch.Watcher;
+import com.coreos.jetcd.common.exception.ClosedClientException;
+import com.coreos.jetcd.common.exception.ClosedWatcherException;
 import com.coreos.jetcd.data.ByteSequence;
 import com.coreos.jetcd.data.KeyValue;
 import com.coreos.jetcd.op.Cmp;
@@ -31,13 +37,21 @@ import com.coreos.jetcd.options.GetOption;
 import com.coreos.jetcd.options.GetOption.SortOrder;
 import com.coreos.jetcd.options.GetOption.SortTarget;
 import com.coreos.jetcd.options.PutOption;
+import com.coreos.jetcd.options.WatchOption;
+import com.coreos.jetcd.options.WatchOption.Builder;
+import com.coreos.jetcd.watch.WatchEvent;
+import com.coreos.jetcd.watch.WatchEvent.EventType;
+import com.coreos.jetcd.watch.WatchResponse;
 import com.rackspace.salus.telemetry.etcd.types.EtcdStorageException;
 import com.rackspace.salus.telemetry.etcd.types.ResolvedZone;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.regex.Matcher;
+import javax.annotation.PreDestroy;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.util.Assert;
 
 @Service
 @Slf4j
@@ -46,6 +60,7 @@ public class ZoneStorage {
   private static final String FMT_BOUND_COUNT = "%010d";
 
   private final Client etcd;
+  private boolean running = true;
 
   @Autowired
   public ZoneStorage(Client etcd) {
@@ -54,9 +69,11 @@ public class ZoneStorage {
 
   @SuppressWarnings("UnstableApiUsage")
   public CompletableFuture<?> registerEnvoyInZone(ResolvedZone zone, String envoyId,
-                                                  String resourceId, long envoyLeaseId) throws EtcdStorageException {
+                                                  String resourceId, long envoyLeaseId)
+      throws EtcdStorageException {
     log.debug("Registering envoy={} with resourceId={} in zone={}",
-        envoyId, resourceId, zone);
+        envoyId, resourceId, zone
+    );
 
     final KV kv = etcd.getKVClient();
 
@@ -96,7 +113,8 @@ public class ZoneStorage {
 
           log.debug("Putting new bound count={} for envoy={} in zone={}", newCount, envoyId, zone);
 
-          final ByteSequence newValue = ByteSequence.fromString(String.format(FMT_BOUND_COUNT,
+          final ByteSequence newValue = ByteSequence.fromString(String.format(
+              FMT_BOUND_COUNT,
               newCount
           ));
 
@@ -118,10 +136,11 @@ public class ZoneStorage {
 
                 if (txnResponse.isSucceeded()) {
                   return CompletableFuture.completedFuture(newCount);
-                }
-                else {
-                  log.debug("Re-trying incrementing bound count of envoy={} in zone={} due to collision",
-                      envoyId, zone);
+                } else {
+                  log.debug(
+                      "Re-trying incrementing bound count of envoy={} in zone={} due to collision",
+                      envoyId, zone
+                  );
                   return incrementBoundCount(zone, envoyId);
                 }
 
@@ -154,5 +173,143 @@ public class ZoneStorage {
 
           }
         });
+  }
+
+  private CompletableFuture<Long> determineWatchSequenceOfExpectedZones() {
+    final ByteSequence trackingKey = ByteSequence.fromString(PREFIX_ZONE_EXPECTED);
+
+    return etcd.getKVClient().txn()
+        .If(
+            // if the prefix tracking key exists?
+            new Cmp(trackingKey, Cmp.Op.GREATER, CmpTarget.version(0))
+        )
+        .Then(
+            // then get the revision of that key
+            Op.get(trackingKey, GetOption.DEFAULT)
+        )
+        .Else(
+            // otherwise, create the tracking key
+            Op.put(trackingKey, ByteSequence.fromString(""), PutOption.DEFAULT)
+        )
+        .commit()
+        .thenApply(txnResponse -> {
+          if (txnResponse.isSucceeded()) {
+            return txnResponse.getGetResponses().get(0).getKvs().get(0).getModRevision() + 1;
+          } else {
+            return 0L;
+          }
+        });
+  }
+
+  /**
+   * Sets up asynchronous watching of the expected zone key range.
+   *
+   * @param listener the listener that will be invoked when changes related to expected zones occur
+   * @return a future that is completed when the watcher is setup and being processed. The contained
+   * {@link Watcher} is provided only for testing/informational purposes.
+   */
+  public CompletableFuture<Watcher> watchExpectedZones(ZoneStorageListener listener) {
+    Assert.notNull(listener, "A ZoneStorageListener is required");
+
+    // first we need to see if a previous app was watching the zones
+    return
+        determineWatchSequenceOfExpectedZones()
+            .thenApply(watchRevision -> {
+              // We need to append the delimiter to the watch path; otherwise, the range-watch would
+              // have picked up our own touches to the tracking key.
+              final String watchPrefixStr = PREFIX_ZONE_EXPECTED + DELIMITER;
+
+              log.debug("Watching {} from revision {}", watchPrefixStr, watchRevision);
+
+              final ByteSequence watchPrefix = ByteSequence
+                  .fromString(watchPrefixStr);
+
+              final Builder watchOptionBuilder = WatchOption.newBuilder()
+                  .withPrefix(watchPrefix)
+                  .withPrevKV(true)
+                  .withRevision(watchRevision);
+
+              final Watcher zoneExpectedWatcher = etcd.getWatchClient().watch(
+                  watchPrefix,
+                  watchOptionBuilder.build()
+              );
+
+              new Thread(() -> {
+                processZoneExpectedWatcher(zoneExpectedWatcher, listener);
+              }, "zoneExpectedWatcher")
+                  .start();
+
+              return zoneExpectedWatcher;
+            });
+  }
+
+  private void processZoneExpectedWatcher(Watcher zoneExpectedWatcher,
+                                          ZoneStorageListener listener) {
+    final ByteSequence trackingKey = ByteSequence.fromString(PREFIX_ZONE_EXPECTED);
+
+    while (running) {
+      try {
+        final WatchResponse response = zoneExpectedWatcher.listen();
+
+        try {
+          for (WatchEvent event : response.getEvents()) {
+
+            final EventType eventType = event.getEventType();
+
+            if (eventType == EventType.PUT) {
+
+              final String keyStr = event.getKeyValue().getKey().toStringUtf8();
+              final Matcher matcher = PTN_ZONE_EXPECTED.matcher(keyStr);
+
+              if (matcher.matches()) {
+                final ResolvedZone resolvedZone = ResolvedZone.fromKeyParts(
+                    matcher.group("tenant"),
+                    matcher.group("zoneId")
+                );
+
+                // prev KV is always populated by event, but a version=0 means it wasn't present in storage
+                if (event.getPrevKV().getVersion() == 0) {
+                  try {
+                    listener.handleNewEnvoyResourceInZone(resolvedZone);
+                  } catch (Exception e) {
+                    log.warn("Unexpected failure within listener={}", listener, e);
+                  }
+                } else {
+                  try {
+                    listener.handleEnvoyResourceReassignedInZone(
+                        resolvedZone,
+                        event.getPrevKV().getValue().toStringUtf8(),
+                        event.getKeyValue().getValue().toStringUtf8()
+                    );
+                  } catch (Exception e) {
+                    log.warn("Unexpected failure within listener={}", listener, e);
+                  }
+                }
+              } else {
+                log.warn("Unable to parse key={}", keyStr);
+              }
+
+            }
+          }
+        } finally {
+          etcd.getKVClient().put(trackingKey, ByteSequence.fromString(""));
+        }
+
+      } catch (InterruptedException e) {
+        log.warn("Interrupted while watching zone expected", e);
+      } catch (ClosedWatcherException | ClosedClientException e) {
+        log.debug("Stopping processing due to closure", e);
+        listener.handleExpectedZoneWatcherClosed(e);
+        return;
+      }
+    }
+
+    listener.handleExpectedZoneWatcherClosed(null);
+
+  }
+
+  @PreDestroy
+  public void stop() {
+    running = false;
   }
 }

--- a/src/main/java/com/rackspace/salus/telemetry/etcd/services/ZoneStorage.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/services/ZoneStorage.java
@@ -53,6 +53,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.util.Assert;
 
+/**
+ * Encapsulates the aspects of reading, updating, and watching the etcd aspect of zones.
+ * The etcd stored aspects of zones are limited to the dynamic aspects need to track the
+ * lease-bounded keys in real-time.
+ */
 @Service
 @Slf4j
 public class ZoneStorage {
@@ -195,7 +200,9 @@ public class ZoneStorage {
             Op.get(trackingKey, GetOption.DEFAULT)
         )
         .Else(
-            // otherwise, create the tracking key
+            // ...otherwise, create the tracking key since we need to bootstrap the tracking key
+            // on very first startup. In production, this is a one-time event, but also enables
+            // seamless development testing.
             Op.put(trackingKey, ByteSequence.fromString(""), PutOption.DEFAULT)
         )
         .commit()

--- a/src/main/java/com/rackspace/salus/telemetry/etcd/services/ZoneStorage.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/services/ZoneStorage.java
@@ -94,6 +94,11 @@ public class ZoneStorage {
   }
 
   public CompletableFuture<Integer> incrementBoundCount(ResolvedZone zone, String envoyId) {
+    return incrementBoundCount(zone, envoyId, 1);
+  }
+
+  public CompletableFuture<Integer> incrementBoundCount(ResolvedZone zone, String envoyId,
+                                                        int size) {
     log.debug("Incrementing bound count of envoy={} in zone={}", envoyId, zone);
 
     final ByteSequence key = buildKey(
@@ -109,7 +114,7 @@ public class ZoneStorage {
 
           final KeyValue kvEntry = getResponse.getKvs().get(0);
           final int prevCount = Integer.parseInt(kvEntry.getValue().toStringUtf8(), 10);
-          final int newCount = prevCount + 1;
+          final int newCount = prevCount + size;
 
           log.debug("Putting new bound count={} for envoy={} in zone={}", newCount, envoyId, zone);
 
@@ -141,7 +146,7 @@ public class ZoneStorage {
                       "Re-trying incrementing bound count of envoy={} in zone={} due to collision",
                       envoyId, zone
                   );
-                  return incrementBoundCount(zone, envoyId);
+                  return incrementBoundCount(zone, envoyId, size);
                 }
 
               });

--- a/src/main/java/com/rackspace/salus/telemetry/etcd/services/ZoneStorageListener.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/services/ZoneStorageListener.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.etcd.services;
+
+import com.coreos.jetcd.common.exception.EtcdException;
+import com.rackspace.salus.telemetry.etcd.types.ResolvedZone;
+
+public interface ZoneStorageListener {
+
+  void handleNewEnvoyResourceInZone(ResolvedZone resolvedZone);
+
+  void handleExpectedZoneWatcherClosed(EtcdException e);
+
+  void handleEnvoyResourceReassignedInZone(ResolvedZone resolvedZone, String prevEnvoyId, String newEnvoyId);
+}

--- a/src/main/java/com/rackspace/salus/telemetry/etcd/types/Keys.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/types/Keys.java
@@ -18,9 +18,13 @@
 
 package com.rackspace.salus.telemetry.etcd.types;
 
+import com.rackspace.salus.telemetry.etcd.EtcdUtils;
 import java.util.regex.Pattern;
 
 public class Keys {
+
+    public static final String DELIMITER = "/";
+
     public static final String FMT_ENVOYS_BY_ID = "/tenants/{tenant}/envoysById/{envoyInstanceId}";
     public static final String FMT_AGENT_INSTALLS = "/agentInstalls/{tenant}/{envoyInstanceId}/{agentType}";
     public static final Pattern PTN_AGENT_INSTALLS = Pattern.compile("/agentInstalls/(.+?)/(.+?)/(.+?)");
@@ -49,4 +53,7 @@ public class Keys {
      * Value is latest attached envoy ID
      */
     public static final String FMT_ZONE_EXPECTED = "/zones/expected/{tenant}/{zoneId}/{resourceId}";
+    public static final Pattern PTN_ZONE_EXPECTED = EtcdUtils.patternFromFormat(FMT_ZONE_EXPECTED);
+
+    public static final String PREFIX_ZONE_EXPECTED = "/zones/expected";
 }

--- a/src/main/java/com/rackspace/salus/telemetry/etcd/types/ResolvedZone.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/types/ResolvedZone.java
@@ -26,14 +26,20 @@ public class ResolvedZone {
 
   String id;
   String tenantId;
-  boolean publicZone;
 
-  public String getTenantId() {
-    return publicZone ? null : tenantId;
+  public ResolvedZone setPublicZone(boolean value) {
+    if (value) {
+      this.tenantId = null;
+    }
+    return this;
+  }
+
+  public boolean isPublicZone() {
+    return this.tenantId == null;
   }
 
   public String getTenantForKey() {
-    if (publicZone) {
+    if (isPublicZone()) {
       return PUBLIC;
     }
     else {
@@ -43,5 +49,23 @@ public class ResolvedZone {
 
   public String getZoneIdForKey() {
     return EtcdUtils.escapePathPart(id);
+  }
+
+  public static ResolvedZone fromKeyParts(String tenant, String zone) {
+
+    final ResolvedZone resolvedZone = new ResolvedZone()
+        .setId(EtcdUtils.unescapePathPart(zone));
+
+    if (!tenant.equals(PUBLIC)) {
+      resolvedZone
+          .setTenantId(tenant)
+          .setPublicZone(false);
+    }
+    else {
+      resolvedZone
+          .setPublicZone(true);
+    }
+
+    return resolvedZone;
   }
 }

--- a/src/test/java/com/rackspace/salus/telemetry/etcd/EtcdUtilsTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/etcd/EtcdUtilsTest.java
@@ -27,6 +27,7 @@ import com.coreos.jetcd.data.ByteSequence;
 import com.rackspace.salus.telemetry.model.AgentType;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.regex.Pattern;
 import org.junit.Test;
 
 public class EtcdUtilsTest {
@@ -146,4 +147,48 @@ public class EtcdUtilsTest {
         assertNull(result);
     }
 
+    @Test
+    public void testUnescapePathPart_null() {
+        final String result = EtcdUtils.unescapePathPart(null);
+
+        assertNull(result);
+    }
+
+    @Test
+    public void testUnescapePathPart_roundTrip() {
+        final String in = EtcdUtils.escapePathPart("public/west");
+        final String result = EtcdUtils.unescapePathPart(in);
+
+        assertEquals("public/west", result);
+    }
+
+    @Test
+    public void testUnescapePathPart_withEscapes() {
+        final String result = EtcdUtils.unescapePathPart("public%2Fwest");
+
+        assertEquals("public/west", result);
+    }
+
+    @Test
+    public void testUnescapePathPart_noEscapes() {
+        final String result = EtcdUtils.unescapePathPart("simple");
+
+        assertEquals("simple", result);
+    }
+
+    @Test
+    public void testPatternFromFormat_fields() {
+        final Pattern result = EtcdUtils
+            .patternFromFormat("/zones/expected/{tenant}/{zoneId}/{resourceId}");
+
+        assertEquals("/zones/expected/(?<tenant>.+?)/(?<zoneId>.+?)/(?<resourceId>.+?)", result.toString());
+    }
+
+    @Test
+    public void testPatternFromFormat_noFields() {
+        final Pattern result = EtcdUtils
+            .patternFromFormat("/zones/expected");
+
+        assertEquals("/zones/expected", result.toString());
+    }
 }

--- a/src/test/java/com/rackspace/salus/telemetry/etcd/services/EnvoyResourceManagementTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/etcd/services/EnvoyResourceManagementTest.java
@@ -129,6 +129,15 @@ public class EnvoyResourceManagementTest {
         verifyDelete(identifierPath);
     }
 
+    @Test
+    public void testgetOne_butThereIsNone() throws ExecutionException, InterruptedException {
+      final ResourceInfo result = envoyResourceManagement
+          .getOne("t-none", "r-none")
+          .get();
+
+      assertNull(result);
+    }
+
     private void verifyResourceInfo(String k, ResourceInfo v, Long leaseId) {
         client.getKVClient().get(buildKey(k))
                 .thenApply(getResponse -> {

--- a/src/test/java/com/rackspace/salus/telemetry/etcd/services/ZoneStorageTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/etcd/services/ZoneStorageTest.java
@@ -16,6 +16,7 @@
 
 package com.rackspace.salus.telemetry.etcd.services;
 
+import static com.rackspace.salus.telemetry.etcd.types.ResolvedZone.createPrivateZone;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.lessThan;
@@ -76,9 +77,7 @@ public class ZoneStorageTest {
 
     final long leaseId = grantLease();
 
-    ResolvedZone zone = new ResolvedZone()
-        .setId("zone-1")
-        .setTenantId("t-1");
+    final ResolvedZone zone = createPrivateZone("t-1", "zone-1");
     zoneStorage.registerEnvoyInZone(zone, "123-456", "r-1", leaseId).join();
 
     final GetResponse activeResponse = client.getKVClient()
@@ -101,9 +100,7 @@ public class ZoneStorageTest {
     // just use one lease for all three
     final long leaseId = grantLease();
 
-    ResolvedZone zone = new ResolvedZone()
-        .setId("zone-1")
-        .setTenantId("t-1");
+    final ResolvedZone zone = createPrivateZone("t-1", "zone-1");
 
     zoneStorage.registerEnvoyInZone(zone, "e-1", "r-1", leaseId).join();
     zoneStorage.registerEnvoyInZone(zone, "e-2", "r-2", leaseId).join();
@@ -136,9 +133,7 @@ public class ZoneStorageTest {
   public void testIncrementBoundMoreThanOne() {
     final long leaseId = grantLease();
 
-    ResolvedZone zone = new ResolvedZone()
-        .setId("zone-1")
-        .setTenantId("t-1");
+    final ResolvedZone zone = createPrivateZone("t-1", "zone-1");
 
     zoneStorage.registerEnvoyInZone(zone, "e-1", "r-1", leaseId).join();
 
@@ -151,9 +146,7 @@ public class ZoneStorageTest {
 
   @Test
   public void testLeastLoaded_emptyZone() {
-    ResolvedZone zone = new ResolvedZone()
-        .setId("zone-nowhere")
-        .setTenantId("t-none");
+    final ResolvedZone zone = createPrivateZone("t-none", "zone-nowhere");
 
     final Optional<String> leastLoaded = zoneStorage.findLeastLoadedEnvoy(zone).join();
     assertThat(leastLoaded.isPresent(), equalTo(false));
@@ -161,9 +154,7 @@ public class ZoneStorageTest {
 
   @Test
   public void testNewExpectedEnvoyResource() throws ExecutionException, InterruptedException {
-    registerAndWatchExpected(new ResolvedZone()
-        .setTenantId("t-1")
-        .setId("z-1"), "r-1", "t-1");
+    registerAndWatchExpected(createPrivateZone("t-1", "z-1"), "r-1", "t-1");
   }
 
   /**
@@ -174,9 +165,7 @@ public class ZoneStorageTest {
   public void testResumingExpectedEnvoyWatch() throws ExecutionException, InterruptedException {
     final String tenant = testName.getMethodName();
 
-    final ResolvedZone resolvedZone = new ResolvedZone()
-        .setTenantId(tenant)
-        .setId("z-1");
+    final ResolvedZone resolvedZone = createPrivateZone(tenant, "z-1");
 
     registerAndWatchExpected(resolvedZone, "r-1", tenant);
 
@@ -223,9 +212,7 @@ public class ZoneStorageTest {
   public void testWatchExpectedZones_reRegister() throws ExecutionException, InterruptedException {
     final String tenant = testName.getMethodName();
 
-    final ResolvedZone resolvedZone = new ResolvedZone()
-        .setTenantId(tenant)
-        .setId("z-1");
+    final ResolvedZone resolvedZone = createPrivateZone(tenant, "z-1");
 
     final ZoneStorageListener listener = Mockito.mock(ZoneStorageListener.class);
 

--- a/src/test/java/com/rackspace/salus/telemetry/etcd/services/ZoneStorageTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/etcd/services/ZoneStorageTest.java
@@ -133,6 +133,23 @@ public class ZoneStorageTest {
   }
 
   @Test
+  public void testIncrementBoundMoreThanOne() {
+    final long leaseId = grantLease();
+
+    ResolvedZone zone = new ResolvedZone()
+        .setId("zone-1")
+        .setTenantId("t-1");
+
+    zoneStorage.registerEnvoyInZone(zone, "e-1", "r-1", leaseId).join();
+
+    assertValueAndLease("/zones/active/t-1/zone-1/e-1", 0, leaseId);
+
+    zoneStorage.incrementBoundCount(zone, "e-1", 12).join();
+
+    assertValueAndLease("/zones/active/t-1/zone-1/e-1", 12, leaseId);
+  }
+
+  @Test
   public void testLeastLoaded_emptyZone() {
     ResolvedZone zone = new ResolvedZone()
         .setId("zone-nowhere")

--- a/src/test/java/com/rackspace/salus/telemetry/etcd/services/ZoneStorageTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/etcd/services/ZoneStorageTest.java
@@ -18,9 +18,15 @@ package com.rackspace.salus.telemetry.etcd.services;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.lessThan;
 import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.notNull;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import com.coreos.jetcd.Client;
+import com.coreos.jetcd.Watch.Watcher;
 import com.coreos.jetcd.data.ByteSequence;
 import com.coreos.jetcd.kv.GetResponse;
 import com.coreos.jetcd.lease.LeaseGrantResponse;
@@ -29,15 +35,21 @@ import io.etcd.jetcd.launcher.junit.EtcdClusterResource;
 import java.net.URI;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestName;
+import org.mockito.Mockito;
 
 public class ZoneStorageTest {
   @Rule
   public final EtcdClusterResource etcd = new EtcdClusterResource("ZoneStorageTest", 1);
+
+  @Rule
+  public TestName testName = new TestName();
 
   private Client client;
 
@@ -55,6 +67,7 @@ public class ZoneStorageTest {
 
   @After
   public void tearDown() {
+    zoneStorage.stop();
     client.close();
   }
 
@@ -127,6 +140,126 @@ public class ZoneStorageTest {
 
     final Optional<String> leastLoaded = zoneStorage.findLeastLoadedEnvoy(zone).join();
     assertThat(leastLoaded.isPresent(), equalTo(false));
+  }
+
+  @Test
+  public void testNewExpectedEnvoyResource() throws ExecutionException, InterruptedException {
+    registerAndWatchExpected(new ResolvedZone()
+        .setTenantId("t-1")
+        .setId("z-1"), "r-1", "t-1");
+  }
+
+  /**
+   * This test simulates the scenario where the zone management application is restarting, but
+   * during the down time a new envoy-resource registered in the zone.
+   */
+  @Test
+  public void testResumingExpectedEnvoyWatch() throws ExecutionException, InterruptedException {
+    final String tenant = testName.getMethodName();
+
+    final ResolvedZone resolvedZone = new ResolvedZone()
+        .setTenantId(tenant)
+        .setId("z-1");
+
+    registerAndWatchExpected(resolvedZone, "r-1", tenant);
+
+    // one envoy-resource has registered, now register another prior to re-watching
+
+    final long leaseId = grantLease();
+    zoneStorage.registerEnvoyInZone(resolvedZone, "e-2", "r-2", leaseId)
+        .join();
+
+    // sanity check KV content
+    final GetResponse r2resp = client.getKVClient().get(
+        ByteSequence.fromString(String.format("/zones/expected/%s/z-1/r-2",
+            tenant
+        ))
+    ).get();
+    assertThat(r2resp.getCount(), equalTo(1L));
+
+    final GetResponse trackingResp = client.getKVClient().get(
+        ByteSequence.fromString("/zones/expected")
+    ).get();
+    assertThat(trackingResp.getCount(), equalTo(1L));
+    // ...and the relative revisions of the tracking key vs the registration while not watching
+    assertThat(trackingResp.getKvs().get(0).getModRevision(), lessThan(r2resp.getKvs().get(0).getModRevision()));
+
+    // Now restart watching, which should pick up from where the other ended
+
+    final ZoneStorageListener listener = Mockito.mock(ZoneStorageListener.class);
+
+    try (Watcher ignored = zoneStorage.watchExpectedZones(listener).get()) {
+
+      verify(listener, timeout(5000)).handleNewEnvoyResourceInZone(resolvedZone);
+
+    } finally {
+      // watcher has been closed
+
+      verify(listener, timeout(5000)).handleExpectedZoneWatcherClosed(notNull());
+
+      verifyNoMoreInteractions(listener);
+    }
+
+  }
+
+  @Test
+  public void testWatchExpectedZones_reRegister() throws ExecutionException, InterruptedException {
+    final String tenant = testName.getMethodName();
+
+    final ResolvedZone resolvedZone = new ResolvedZone()
+        .setTenantId(tenant)
+        .setId("z-1");
+
+    final ZoneStorageListener listener = Mockito.mock(ZoneStorageListener.class);
+
+    try (Watcher ignored = zoneStorage.watchExpectedZones(listener).get()) {
+
+      final long leaseId = grantLease();
+
+      zoneStorage.registerEnvoyInZone(resolvedZone, "e-1", "r-1", leaseId)
+          .join();
+
+      verify(listener, timeout(5000)).handleNewEnvoyResourceInZone(resolvedZone);
+
+      zoneStorage.registerEnvoyInZone(resolvedZone, "e-2", "r-1", leaseId)
+          .join();
+
+      verify(listener, timeout(5000)).handleEnvoyResourceReassignedInZone(
+          resolvedZone, "e-1", "e-2");
+
+    } finally {
+      // watcher has been closed
+
+      // it is expected that watcher is closed with exception when closed prior to stopping the component
+      verify(listener, timeout(5000)).handleExpectedZoneWatcherClosed(notNull());
+
+      verifyNoMoreInteractions(listener);
+    }
+
+  }
+
+  private void registerAndWatchExpected(ResolvedZone resolvedZone, String resourceId, String tenant)
+      throws InterruptedException, ExecutionException {
+    final ZoneStorageListener listener = Mockito.mock(ZoneStorageListener.class);
+
+    try (Watcher ignored = zoneStorage.watchExpectedZones(listener).get()) {
+
+      final long leaseId = grantLease();
+
+      zoneStorage.registerEnvoyInZone(resolvedZone, "e-1", resourceId, leaseId)
+          .join();
+
+      verify(listener, timeout(5000)).handleNewEnvoyResourceInZone(resolvedZone);
+
+
+    } finally {
+      // watcher has been closed
+
+      // it is expected that watcher is closed with exception when closed prior to stopping the component
+      verify(listener, timeout(5000)).handleExpectedZoneWatcherClosed(notNull());
+
+      verifyNoMoreInteractions(listener);
+    }
   }
 
   private void assertValueAndLease(String key, int expectedCount, long leaseId) {

--- a/src/test/java/com/rackspace/salus/telemetry/etcd/types/ResolvedZoneTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/etcd/types/ResolvedZoneTest.java
@@ -17,9 +17,11 @@
 package com.rackspace.salus.telemetry.etcd.types;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 
+import com.rackspace.salus.telemetry.etcd.EtcdUtils;
 import org.junit.Test;
 
 public class ResolvedZoneTest {
@@ -36,8 +38,8 @@ public class ResolvedZoneTest {
   @Test
   public void getTenantForKey_public() {
     final ResolvedZone zone = new ResolvedZone()
-        .setPublicZone(true)
-        .setTenantId("tenant-1");
+        .setTenantId("tenant-1")
+        .setPublicZone(true);
 
     assertThat(zone.getTenantForKey(), equalTo(ResolvedZone.PUBLIC));
   }
@@ -45,8 +47,8 @@ public class ResolvedZoneTest {
   @Test
   public void getTenantAlwaysNullForPublic() {
     final ResolvedZone zone = new ResolvedZone()
-        .setPublicZone(true)
-        .setTenantId("tenant-1");
+        .setTenantId("tenant-1")
+        .setPublicZone(true);
 
     assertThat(zone.getTenantId(), nullValue());
   }
@@ -59,5 +61,27 @@ public class ResolvedZoneTest {
         .setTenantId("tenant-1");
 
     assertThat(zone.getZoneIdForKey(), equalTo("companyName%2Fwest"));
+  }
+
+  @Test
+  public void testFromKeyParts_public() {
+    final ResolvedZone resolvedZone = ResolvedZone
+        .fromKeyParts(ResolvedZone.PUBLIC, EtcdUtils.escapePathPart("public/west"));
+
+    assertThat(resolvedZone, notNullValue());
+    assertThat(resolvedZone.isPublicZone(), equalTo(true));
+    assertThat(resolvedZone.getId(), equalTo("public/west"));
+    assertThat(resolvedZone.getTenantId(), nullValue());
+  }
+
+  @Test
+  public void testFromKeyParts_private() {
+    final ResolvedZone resolvedZone = ResolvedZone
+        .fromKeyParts("t-1", EtcdUtils.escapePathPart("custom/division1"));
+
+    assertThat(resolvedZone, notNullValue());
+    assertThat(resolvedZone.isPublicZone(), equalTo(false));
+    assertThat(resolvedZone.getId(), equalTo("custom/division1"));
+    assertThat(resolvedZone.getTenantId(), equalTo("t-1"));
   }
 }

--- a/src/test/java/com/rackspace/salus/telemetry/etcd/types/ResolvedZoneTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/etcd/types/ResolvedZoneTest.java
@@ -16,6 +16,8 @@
 
 package com.rackspace.salus.telemetry.etcd.types;
 
+import static com.rackspace.salus.telemetry.etcd.types.ResolvedZone.createPrivateZone;
+import static com.rackspace.salus.telemetry.etcd.types.ResolvedZone.createPublicZone;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
@@ -28,37 +30,28 @@ public class ResolvedZoneTest {
 
   @Test
   public void getTenantForKey_nonPublic() {
-    final ResolvedZone zone = new ResolvedZone()
-        .setPublicZone(false)
-        .setTenantId("tenant-1");
+    final ResolvedZone zone = createPrivateZone("tenant-1", "z-1");
 
     assertThat(zone.getTenantForKey(), equalTo("tenant-1"));
   }
 
   @Test
   public void getTenantForKey_public() {
-    final ResolvedZone zone = new ResolvedZone()
-        .setTenantId("tenant-1")
-        .setPublicZone(true);
+    final ResolvedZone zone = createPublicZone("z-1");
 
     assertThat(zone.getTenantForKey(), equalTo(ResolvedZone.PUBLIC));
   }
 
   @Test
   public void getTenantAlwaysNullForPublic() {
-    final ResolvedZone zone = new ResolvedZone()
-        .setTenantId("tenant-1")
-        .setPublicZone(true);
+    final ResolvedZone zone = createPublicZone("z-1");
 
     assertThat(zone.getTenantId(), nullValue());
   }
 
   @Test
   public void getZoneIdForKey() {
-    final ResolvedZone zone = new ResolvedZone()
-        .setId("companyName/west")
-        .setPublicZone(true)
-        .setTenantId("tenant-1");
+    final ResolvedZone zone = createPublicZone("companyName/west");
 
     assertThat(zone.getZoneIdForKey(), equalTo("companyName%2Fwest"));
   }


### PR DESCRIPTION
# Resolves

Part of https://jira.rax.io/browse/SALUS-263

# What

These changes encapsulate the etcd specific parts of watching the expected zone keys and then the new zone management code (soon to be PR'ed) will use these to kick off and listen for zone related changes.

## How to test

Unit tests have been added.