### PR TITLE
Add ability to get number of active envoys in zone

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/etcd/services/ZoneStorage.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/services/ZoneStorage.java
@@ -30,6 +30,7 @@ import com.coreos.jetcd.common.exception.ClosedClientException;
 import com.coreos.jetcd.common.exception.ClosedWatcherException;
 import com.coreos.jetcd.data.ByteSequence;
 import com.coreos.jetcd.data.KeyValue;
+import com.coreos.jetcd.kv.GetResponse;
 import com.coreos.jetcd.op.Cmp;
 import com.coreos.jetcd.op.CmpTarget;
 import com.coreos.jetcd.op.Op;
@@ -185,6 +186,19 @@ public class ZoneStorage {
 
           }
         });
+  }
+
+  public CompletableFuture<Long> getActiveEnvoyCountForZone(ResolvedZone zone) {
+      final ByteSequence prefix =
+              buildKey(FMT_ZONE_ACTIVE, zone.getTenantForKey(), zone.getZoneIdForKey(), "");
+
+      return etcd.getKVClient().get(
+              prefix,
+              GetOption.newBuilder()
+                      .withPrefix(prefix)
+                      .withCountOnly(true)
+                      .build()
+      ).thenApply(GetResponse::getCount);
   }
 
   private CompletableFuture<Long> determineWatchSequenceOfExpectedZones() {

--- a/src/test/java/com/rackspace/salus/telemetry/etcd/services/ZoneStorageTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/etcd/services/ZoneStorageTest.java
@@ -96,6 +96,20 @@ public class ZoneStorageTest {
   }
 
   @Test
+  public void testGetActiveEnvoyCountForZone() {
+    final long leaseId = grantLease();
+    final ResolvedZone zone = createPrivateZone("t-1", "zone-1");
+
+    assertThat(zoneStorage.getActiveEnvoyCountForZone(zone).join(), equalTo(0L));
+
+    zoneStorage.registerEnvoyInZone(zone, "e-1", "r-1", leaseId).join();
+    zoneStorage.registerEnvoyInZone(zone, "e-2", "r-2", leaseId).join();
+    zoneStorage.registerEnvoyInZone(zone, "e-3", "r-3", leaseId).join();
+
+    assertThat(zoneStorage.getActiveEnvoyCountForZone(zone).join(), equalTo(3L));
+  }
+
+  @Test
   public void testUpdateBound_and_leastLoaded() {
     // just use one lease for all three
     final long leaseId = grantLease();


### PR DESCRIPTION
# What

Adds a method to get the number of active envoys for a zone.

# Why

Before deleting a zone we do checks to see that it has no envoys connected and fail if it does.