### PR TITLE
Renaming id of ResolveZone to name to align with zone management

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/etcd/types/ResolvedZone.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/types/ResolvedZone.java
@@ -34,25 +34,27 @@ public class ResolvedZone {
 
   public static final String PUBLIC = "_PUBLIC_";
 
-  final String id;
+  public static final String PUBLIC_PREFIX = "public/";
+
+  final String name;
   final String tenantId;
 
-  private ResolvedZone(String zoneId) {
+  private ResolvedZone(String zoneName) {
     this.tenantId = null; // indicates public
-    this.id = zoneId;
+    this.name = zoneName;
   }
 
-  private ResolvedZone(String zoneTenantId, String zoneId) {
+  private ResolvedZone(String zoneTenantId, String zoneName) {
     this.tenantId = zoneTenantId;
-    this.id = zoneId;
+    this.name = zoneName;
   }
 
-  public static ResolvedZone createPublicZone(String zoneId) {
-    return new ResolvedZone(zoneId);
+  public static ResolvedZone createPublicZone(String zoneName) {
+    return new ResolvedZone(zoneName);
   }
 
-  public static ResolvedZone createPrivateZone(String zoneTenantId, String zoneId) {
-    return new ResolvedZone(zoneTenantId, zoneId);
+  public static ResolvedZone createPrivateZone(String zoneTenantId, String zoneName) {
+    return new ResolvedZone(zoneTenantId, zoneName);
   }
 
   public boolean isPublicZone() {
@@ -69,17 +71,17 @@ public class ResolvedZone {
   }
 
   public String getZoneIdForKey() {
-    return EtcdUtils.escapePathPart(id);
+    return EtcdUtils.escapePathPart(name);
   }
 
   public static ResolvedZone fromKeyParts(String tenant, String zone) {
 
-    final String correctedZoneId = EtcdUtils.unescapePathPart(zone);
+    final String correctedZoneName = EtcdUtils.unescapePathPart(zone);
     if (!tenant.equals(PUBLIC)) {
-      return createPrivateZone(tenant, correctedZoneId);
+      return createPrivateZone(tenant, correctedZoneName);
     }
     else {
-      return createPublicZone(correctedZoneId);
+      return createPublicZone(correctedZoneName);
     }
   }
 }

--- a/src/test/java/com/rackspace/salus/telemetry/etcd/types/ResolvedZoneTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/etcd/types/ResolvedZoneTest.java
@@ -63,7 +63,7 @@ public class ResolvedZoneTest {
 
     assertThat(resolvedZone, notNullValue());
     assertThat(resolvedZone.isPublicZone(), equalTo(true));
-    assertThat(resolvedZone.getId(), equalTo("public/west"));
+    assertThat(resolvedZone.getName(), equalTo("public/west"));
     assertThat(resolvedZone.getTenantId(), nullValue());
   }
 
@@ -74,7 +74,7 @@ public class ResolvedZoneTest {
 
     assertThat(resolvedZone, notNullValue());
     assertThat(resolvedZone.isPublicZone(), equalTo(false));
-    assertThat(resolvedZone.getId(), equalTo("custom/division1"));
+    assertThat(resolvedZone.getName(), equalTo("custom/division1"));
     assertThat(resolvedZone.getTenantId(), equalTo("t-1"));
   }
 }


### PR DESCRIPTION
# What

With the changes in https://github.com/racker/salus-telemetry-monitor-management/pull/29 we have solidified the field for a zone's name, such as "public/west", vs its `id` which is actually an internal database ID.

# How

Refer to `name` rather than `id` to emphasize the relationship to `Zone`'s fields.

## How to test

Unit test updated