### PR TITLE
Improve handling of missing agent release during install

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,23 +1,23 @@
 # Resolves
 
-    <Jira or Github issue reference(s)>
+<Jira or Github issue reference(s)>
 
 # What
 
-    <What is this PR is trying to accomplish?>
+<What is this PR is trying to accomplish?>
 
 # How
 
-    <How is the PR designed to solve the problem?>
+<How is the PR designed to solve the problem?>
 
 ## How to test
 
-    <instructions for verifying the changes specific to this PR>
+<instructions for verifying the changes specific to this PR>
 
 # Why
 
-    <Why was the final approach taken? Were alternatives considered?>
+<Why was the final approach taken? Were alternatives considered?>
 
 # TODO
 
-    <outstanding tasks before this PR is considered 'ready'>
+<outstanding tasks before this PR is considered 'ready'>

--- a/src/main/java/com/rackspace/salus/telemetry/etcd/services/AgentsCatalogService.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/services/AgentsCatalogService.java
@@ -296,7 +296,7 @@ public class AgentsCatalogService {
             .get(buildKey("/agentsById/{agentId}", agentInfoId))
             .thenApply(getResponse -> {
                 if (getResponse.getCount() == 0) {
-                    return null;
+                    throw new NotFoundException("Unable to find agent release by ID");
                 }
 
                 try {


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-370

# What

When using the public API to perform an agent installation, it would fail with a 500 and NullPointerException when the given `agentReleaseId` didn't exist.

# How

Throw a `NotFoundException` which eventually gets picked up by the Spring MVC layer when consuming the completable future.

## How to test

Unit test added