### PR TITLE
Support zone rebalancing with getZoneBindingCounts

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/etcd/services/ZoneNameValidators.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/services/ZoneNameValidators.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.etcd.services;
+
+import com.rackspace.salus.telemetry.etcd.types.PrivateZoneName;
+import com.rackspace.salus.telemetry.etcd.types.PublicZoneName;
+import com.rackspace.salus.telemetry.etcd.types.ResolvedZone;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+/**
+ * Contains validators of the {@link PublicZoneName} and {@link PrivateZoneName}
+ * custom constraints.
+ */
+public class ZoneNameValidators {
+
+  public static class Public implements ConstraintValidator<PublicZoneName, String> {
+
+    public void initialize(PublicZoneName constraint) { }
+
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+      return value != null && value.startsWith(ResolvedZone.PUBLIC_PREFIX);
+    }
+  }
+
+  public static class Private implements ConstraintValidator<PrivateZoneName, String> {
+
+    public void initialize(PrivateZoneName constraint) { }
+
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+      return value != null && !value.startsWith(ResolvedZone.PUBLIC_PREFIX);
+    }
+
+  }
+}

--- a/src/main/java/com/rackspace/salus/telemetry/etcd/types/PrivateZoneName.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/types/PrivateZoneName.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.etcd.types;
+
+import com.rackspace.salus.telemetry.etcd.services.ZoneNameValidators;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+/**
+ * Declares that the annotated parameter or field must be a private zone name.
+ */
+@Target({ElementType.PARAMETER, ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Constraint(validatedBy = ZoneNameValidators.Private.class)
+public @interface PrivateZoneName {
+
+  String message() default "zone name must be private";
+
+  Class<?>[] groups() default {};
+
+  Class<? extends Payload>[] payload() default {};
+
+}

--- a/src/main/java/com/rackspace/salus/telemetry/etcd/types/PublicZoneName.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/types/PublicZoneName.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.etcd.types;
+
+import com.rackspace.salus.telemetry.etcd.services.ZoneNameValidators;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+/**
+ * Declares that the annotated parameter or field must be a public zone name.
+ */
+@Target({ElementType.PARAMETER, ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Constraint(validatedBy = ZoneNameValidators.Public.class)
+public @interface PublicZoneName {
+
+  String message() default "zone name must be public";
+
+  Class<?>[] groups() default {};
+
+  Class<? extends Payload>[] payload() default {};
+
+}

--- a/src/test/java/com/rackspace/salus/telemetry/etcd/services/ZoneNameValidatorsTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/etcd/services/ZoneNameValidatorsTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.etcd.services;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertThat;
+
+import com.rackspace.salus.telemetry.etcd.types.PrivateZoneName;
+import com.rackspace.salus.telemetry.etcd.types.PublicZoneName;
+import java.util.Set;
+import javax.validation.ConstraintViolation;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
+
+public class ZoneNameValidatorsTest {
+  private LocalValidatorFactoryBean validatorFactoryBean;
+
+  @Before
+  public void setUp() {
+    validatorFactoryBean = new LocalValidatorFactoryBean();
+    validatorFactoryBean.afterPropertiesSet();
+  }
+
+  @Test
+  public void testPublicZoneName_valid() {
+    final WithPublicZoneName obj = new WithPublicZoneName();
+    obj.zoneName = "public/west";
+
+    final Set<ConstraintViolation<WithPublicZoneName>> results = validatorFactoryBean
+        .validate(obj);
+
+    assertThat(results, hasSize(0));
+  }
+
+  @Test
+  public void testPublicZoneName_invalid() {
+    final WithPublicZoneName obj = new WithPublicZoneName();
+    obj.zoneName = "notPublic";
+
+    final Set<ConstraintViolation<WithPublicZoneName>> results = validatorFactoryBean
+        .validate(obj);
+
+    assertThat(results, hasSize(1));
+    assertThat(
+        results.iterator().next().getConstraintDescriptor().getAnnotation().annotationType(),
+        equalTo(PublicZoneName.class)
+    );
+  }
+
+  @Test
+  public void testPrivateZoneName_valid() {
+    final WithPrivateZoneName obj = new WithPrivateZoneName();
+    obj.zoneName = "dev";
+
+    final Set<ConstraintViolation<WithPrivateZoneName>> results = validatorFactoryBean
+        .validate(obj);
+
+    assertThat(results, hasSize(0));
+  }
+
+  @Test
+  public void testPrivateZoneName_invalid() {
+    final WithPrivateZoneName obj = new WithPrivateZoneName();
+    obj.zoneName = "public/any";
+
+    final Set<ConstraintViolation<WithPrivateZoneName>> results = validatorFactoryBean
+        .validate(obj);
+
+    assertThat(results, hasSize(1));
+    assertThat(
+        results.iterator().next().getConstraintDescriptor().getAnnotation().annotationType(),
+        equalTo(PrivateZoneName.class)
+    );
+  }
+
+  static class WithPublicZoneName {
+    @PublicZoneName
+    String zoneName;
+  }
+
+  static class WithPrivateZoneName {
+    @PrivateZoneName
+    String zoneName;
+  }
+}


### PR DESCRIPTION
# Resolves

Part of https://jira.rax.io/browse/SALUS-294

# What

The rebalancing code in monitor management needed the ability to query for the per-envoy-resource assignment accounts within a given zone.

It also needs to do a "bulk decrement" of the active envoy-resource assignments, so I generalized the existing method by renaming it and fixing the log messages.

## How to test

Unit tests have been added