### PR TITLE
Upgraded to jetcd 0.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <java.version>11</java.version>
-    <jetcd.version>0.0.2</jetcd.version>
+    <jetcd.version>0.3.0</jetcd.version>
     <jacoco-maven-plugin.version>0.8.2</jacoco-maven-plugin.version>
   </properties>
 
@@ -53,7 +53,7 @@
       <version>0.1.0-SNAPSHOT</version>
     </dependency>
     <dependency>
-      <groupId>com.coreos</groupId>
+      <groupId>io.etcd</groupId>
       <artifactId>jetcd-core</artifactId>
       <version>${jetcd.version}</version>
     </dependency>
@@ -77,9 +77,9 @@
     </dependency>
 
     <dependency>
-      <groupId>com.github.mxsm</groupId>
+      <groupId>io.etcd</groupId>
       <artifactId>jetcd-launcher</artifactId>
-      <version>0.3.6</version>
+      <version>${jetcd.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/src/main/java/com/rackspace/salus/telemetry/etcd/EtcdUtils.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/EtcdUtils.java
@@ -18,18 +18,19 @@
 
 package com.rackspace.salus.telemetry.etcd;
 
-import com.coreos.jetcd.api.DeleteRangeResponse;
-import com.coreos.jetcd.api.RangeResponse;
-import com.coreos.jetcd.data.ByteSequence;
-import com.coreos.jetcd.data.KeyValue;
-import com.coreos.jetcd.kv.DeleteResponse;
-import com.coreos.jetcd.kv.GetResponse;
-import com.coreos.jetcd.kv.PutResponse;
-import com.coreos.jetcd.kv.TxnResponse;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.protobuf.ByteString;
+import io.etcd.jetcd.ByteSequence;
+import io.etcd.jetcd.KeyValue;
+import io.etcd.jetcd.api.DeleteRangeResponse;
+import io.etcd.jetcd.api.RangeResponse;
+import io.etcd.jetcd.kv.DeleteResponse;
+import io.etcd.jetcd.kv.GetResponse;
+import io.etcd.jetcd.kv.PutResponse;
+import io.etcd.jetcd.kv.TxnResponse;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BinaryOperator;
@@ -43,6 +44,10 @@ import java.util.regex.Pattern;
 public class EtcdUtils {
 
     private static final Pattern KEY_PLACEHOLDER = Pattern.compile("\\{.+?\\}");
+
+    public static ByteSequence fromString(String utf8string) {
+        return ByteSequence.from(utf8string, StandardCharsets.UTF_8);
+    }
 
     /**
      * Replaces placeholders in the <code>format</code> string with the <code>values</code>
@@ -78,7 +83,7 @@ public class EtcdUtils {
         }
         matcher.appendTail(sb);
 
-        return ByteSequence.fromString(sb.toString());
+        return fromString(sb.toString());
     }
 
     /**
@@ -117,7 +122,7 @@ public class EtcdUtils {
     }
 
     public static ByteSequence buildValue(ObjectMapper objectMapper, Object o) throws JsonProcessingException {
-        return ByteSequence.fromBytes(
+        return ByteSequence.from(
                 objectMapper.writeValueAsBytes(o)
         );
     }
@@ -134,7 +139,7 @@ public class EtcdUtils {
      */
     public static CompletableFuture<PutResponse> completedPutResponse() {
         return CompletableFuture.completedFuture(
-                new PutResponse(com.coreos.jetcd.api.PutResponse.newBuilder()
+                new PutResponse(io.etcd.jetcd.api.PutResponse.newBuilder()
                         .build())
         );
     }
@@ -151,7 +156,7 @@ public class EtcdUtils {
 
     public static CompletableFuture<TxnResponse> completedTxnResponse() {
         return CompletableFuture.completedFuture(new TxnResponse(
-            com.coreos.jetcd.api.TxnResponse.newBuilder().build()
+            io.etcd.jetcd.api.TxnResponse.newBuilder().build()
         ));
     }
 
@@ -188,7 +193,7 @@ public class EtcdUtils {
                 new GetResponse(
                         RangeResponse.newBuilder()
                                 .addKvs(
-                                        com.coreos.jetcd.api.KeyValue.newBuilder()
+                                        io.etcd.jetcd.api.KeyValue.newBuilder()
                                                 .setKey(ByteString.copyFromUtf8(key))
                                                 .setValue(ByteString.copyFrom(
                                                         objectMapper.writeValueAsBytes(value)

--- a/src/main/java/com/rackspace/salus/telemetry/etcd/EtcdUtils.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/EtcdUtils.java
@@ -43,6 +43,7 @@ import java.util.regex.Pattern;
  */
 public class EtcdUtils {
 
+    public static final int EXIT_CODE_ETCD_FAILED = 1;
     private static final Pattern KEY_PLACEHOLDER = Pattern.compile("\\{.+?\\}");
 
     public static ByteSequence fromString(String utf8string) {

--- a/src/main/java/com/rackspace/salus/telemetry/etcd/TelemetryCoreEtcdModule.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/TelemetryCoreEtcdModule.java
@@ -16,9 +16,9 @@
 
 package com.rackspace.salus.telemetry.etcd;
 
-import com.coreos.jetcd.Client;
 import com.rackspace.salus.common.util.KeyHashing;
 import com.rackspace.salus.telemetry.etcd.services.EtcdHealthIndicator;
+import io.etcd.jetcd.Client;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.context.annotation.Bean;

--- a/src/main/java/com/rackspace/salus/telemetry/etcd/services/EnvoyLeaseTracking.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/services/EnvoyLeaseTracking.java
@@ -20,9 +20,9 @@ package com.rackspace.salus.telemetry.etcd.services;
 
 import static com.rackspace.salus.telemetry.etcd.EtcdUtils.buildKey;
 
-import com.coreos.jetcd.Client;
 import com.rackspace.salus.telemetry.etcd.EtcdProperties;
 import com.rackspace.salus.telemetry.etcd.types.Keys;
+import io.etcd.jetcd.Client;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/rackspace/salus/telemetry/etcd/services/EnvoyResourceManagement.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/services/EnvoyResourceManagement.java
@@ -21,26 +21,28 @@ package com.rackspace.salus.telemetry.etcd.services;
 import static com.rackspace.salus.telemetry.etcd.EtcdUtils.buildKey;
 import static com.rackspace.salus.telemetry.etcd.EtcdUtils.parseValue;
 
-import com.coreos.jetcd.Client;
-import com.coreos.jetcd.Watch;
-import com.coreos.jetcd.data.ByteSequence;
-import com.coreos.jetcd.data.KeyValue;
-import com.coreos.jetcd.kv.GetResponse;
-import com.coreos.jetcd.options.GetOption;
-import com.coreos.jetcd.options.PutOption;
-import com.coreos.jetcd.options.WatchOption;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.rackspace.salus.common.util.KeyHashing;
 import com.rackspace.salus.telemetry.etcd.EtcdUtils;
 import com.rackspace.salus.telemetry.etcd.types.Keys;
 import com.rackspace.salus.telemetry.model.ResourceInfo;
+import io.etcd.jetcd.ByteSequence;
+import io.etcd.jetcd.Client;
+import io.etcd.jetcd.KeyValue;
+import io.etcd.jetcd.Watch;
+import io.etcd.jetcd.kv.GetResponse;
+import io.etcd.jetcd.options.GetOption;
+import io.etcd.jetcd.options.PutOption;
+import io.etcd.jetcd.options.WatchOption;
+import io.etcd.jetcd.watch.WatchResponse;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -93,7 +95,7 @@ public class EnvoyResourceManagement {
         final String resourceKeyHash = hashing.hash(resourceKey);
         final ByteSequence resourceInfoBytes;
         try {
-            resourceInfoBytes = ByteSequence.fromBytes(objectMapper.writeValueAsBytes(resourceInfo));
+            resourceInfoBytes = ByteSequence.from(objectMapper.writeValueAsBytes(resourceInfo));
         } catch (JsonProcessingException e) {
             throw new RuntimeException("Failed to marshal ResourceInfo", e);
         }
@@ -171,9 +173,13 @@ public class EnvoyResourceManagement {
                 GetOption.newBuilder().withRange(buildKey(prefix, max + '\0')).build());
     }
 
-    public Watch.Watcher getWatchOverRange(String prefix, String min, String max, long revision) {
-        return etcd.getWatchClient().watch(buildKey(prefix, min),
-                WatchOption.newBuilder().withRange(buildKey(prefix, max + '\0'))
-                        .withPrevKV(true).withRevision(revision).build());
+    public Watch.Watcher createWatchOverRange(String prefix, String min, String max, long revision,
+                                              Consumer<WatchResponse> onNext) {
+      return etcd.getWatchClient().watch(
+          buildKey(prefix, min),
+          WatchOption.newBuilder().withRange(buildKey(prefix, max + '\0'))
+              .withPrevKV(true).withRevision(revision).build(),
+          onNext
+      );
     }
 }

--- a/src/main/java/com/rackspace/salus/telemetry/etcd/services/EtcdHealthIndicator.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/services/EtcdHealthIndicator.java
@@ -16,9 +16,9 @@
 
 package com.rackspace.salus.telemetry.etcd.services;
 
-import com.coreos.jetcd.Client;
-import com.coreos.jetcd.data.ByteSequence;
-import com.coreos.jetcd.kv.GetResponse;
+import com.rackspace.salus.telemetry.etcd.EtcdUtils;
+import io.etcd.jetcd.Client;
+import io.etcd.jetcd.kv.GetResponse;
 import java.util.concurrent.ExecutionException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.health.Health;
@@ -41,7 +41,7 @@ public class EtcdHealthIndicator implements HealthIndicator {
   @Override
   public Health health() {
     try {
-      final GetResponse resp = etcd.getKVClient().get(ByteSequence.fromString("/"))
+      final GetResponse resp = etcd.getKVClient().get(EtcdUtils.fromString("/"))
           .get();
       return Health.up().build();
     } catch (InterruptedException | ExecutionException e) {

--- a/src/main/java/com/rackspace/salus/telemetry/etcd/services/WorkAllocationPartitionService.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/services/WorkAllocationPartitionService.java
@@ -2,23 +2,24 @@ package com.rackspace.salus.telemetry.etcd.services;
 
 import static com.rackspace.salus.telemetry.etcd.EtcdUtils.buildKey;
 
-import com.coreos.jetcd.Client;
-import com.coreos.jetcd.data.ByteSequence;
-import com.coreos.jetcd.kv.TxnResponse;
-import com.coreos.jetcd.op.Op;
-import com.coreos.jetcd.options.DeleteOption;
-import com.coreos.jetcd.options.GetOption;
-import com.coreos.jetcd.options.GetOption.SortOrder;
-import com.coreos.jetcd.options.GetOption.SortTarget;
-import com.coreos.jetcd.options.PutOption;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.rackspace.salus.common.util.KeyHashing;
 import com.rackspace.salus.telemetry.etcd.types.KeyRange;
 import com.rackspace.salus.telemetry.etcd.types.Keys;
 import com.rackspace.salus.telemetry.etcd.types.WorkAllocationRealm;
+import io.etcd.jetcd.ByteSequence;
+import io.etcd.jetcd.Client;
+import io.etcd.jetcd.kv.TxnResponse;
+import io.etcd.jetcd.op.Op;
+import io.etcd.jetcd.options.DeleteOption;
+import io.etcd.jetcd.options.GetOption;
+import io.etcd.jetcd.options.GetOption.SortOrder;
+import io.etcd.jetcd.options.GetOption.SortTarget;
+import io.etcd.jetcd.options.PutOption;
 import java.io.IOException;
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
@@ -84,7 +85,7 @@ public class WorkAllocationPartitionService {
                         .readValue(keyValue.getValue().getBytes(), KeyRange.class);
                   } catch (IOException e) {
                     log.warn("Failed to deserialize keyValue={} for realm={}",
-                        keyValue.getKey().toStringUtf8(), realm, e
+                        keyValue.getKey().toString(StandardCharsets.UTF_8), realm, e
                     );
                     return null;
                   }
@@ -122,7 +123,7 @@ public class WorkAllocationPartitionService {
       final ByteSequence value;
       try {
         value = ByteSequence
-            .fromBytes(objectMapper.writeValueAsBytes(keyRange));
+            .from(objectMapper.writeValueAsBytes(keyRange));
       } catch (JsonProcessingException e) {
         log.error("Failed to serialize keyRange={}", keyRange, e);
         return CompletableFuture.completedFuture(false);

--- a/src/main/java/com/rackspace/salus/telemetry/etcd/types/KeyedValue.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/types/KeyedValue.java
@@ -18,7 +18,7 @@
 
 package com.rackspace.salus.telemetry.etcd.types;
 
-import com.coreos.jetcd.data.ByteSequence;
+import io.etcd.jetcd.ByteSequence;
 import lombok.Data;
 
 /**
@@ -38,7 +38,7 @@ import lombok.Data;
          );
      } catch (IOException e) {
          log.warn("Unable to parse AgentInstallSelector from {}",
-         kv.getValue().toStringUtf8(), e);
+         kv.getValue().toString(StandardCharsets.UTF_8), e);
          return null;
      }
  })

--- a/src/test/java/com/rackspace/salus/telemetry/etcd/EtcdUtilsTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/etcd/EtcdUtilsTest.java
@@ -23,8 +23,9 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-import com.coreos.jetcd.data.ByteSequence;
 import com.rackspace.salus.telemetry.model.AgentType;
+import io.etcd.jetcd.ByteSequence;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Pattern;
@@ -39,14 +40,15 @@ public class EtcdUtilsTest {
             "t1", AgentType.FILEBEAT, "ais1"
         );
 
-        assertEquals("/tenants/t1/agentInstallSelectors/FILEBEAT/ais1", result.toStringUtf8());
+        assertEquals("/tenants/t1/agentInstallSelectors/FILEBEAT/ais1", result.toString(
+            StandardCharsets.UTF_8));
     }
 
     @Test
     public void buildKey_noVars() {
         final ByteSequence result = EtcdUtils.buildKey("/agentInstalls");
 
-        assertEquals("/agentInstalls", result.toStringUtf8());
+        assertEquals("/agentInstalls", result.toString(StandardCharsets.UTF_8));
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/src/test/java/com/rackspace/salus/telemetry/etcd/services/EnvoyLeaseTrackingTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/etcd/services/EnvoyLeaseTrackingTest.java
@@ -21,17 +21,17 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.coreos.jetcd.Client;
-import com.coreos.jetcd.KV;
-import com.coreos.jetcd.Lease;
-import com.coreos.jetcd.api.KeyValue;
-import com.coreos.jetcd.api.RangeResponse;
-import com.coreos.jetcd.data.ByteSequence;
-import com.coreos.jetcd.kv.GetResponse;
-import com.coreos.jetcd.lease.LeaseGrantResponse;
-import com.coreos.jetcd.lease.LeaseKeepAliveResponse;
-import com.coreos.jetcd.lease.LeaseRevokeResponse;
 import com.rackspace.salus.telemetry.etcd.EtcdProperties;
+import com.rackspace.salus.telemetry.etcd.EtcdUtils;
+import io.etcd.jetcd.Client;
+import io.etcd.jetcd.KV;
+import io.etcd.jetcd.Lease;
+import io.etcd.jetcd.api.KeyValue;
+import io.etcd.jetcd.api.RangeResponse;
+import io.etcd.jetcd.kv.GetResponse;
+import io.etcd.jetcd.lease.LeaseGrantResponse;
+import io.etcd.jetcd.lease.LeaseKeepAliveResponse;
+import io.etcd.jetcd.lease.LeaseRevokeResponse;
 import java.util.concurrent.CompletableFuture;
 import org.junit.Before;
 import org.junit.Test;
@@ -82,7 +82,7 @@ public class EnvoyLeaseTrackingTest {
 
     @Test
     public void testRetrieve() {
-        when(kv.get(ByteSequence.fromString("/tenants/t1/envoysById/e1")))
+        when(kv.get(EtcdUtils.fromString("/tenants/t1/envoysById/e1")))
             .thenReturn(
                 CompletableFuture.completedFuture(
                     new GetResponse(RangeResponse.newBuilder()
@@ -96,11 +96,12 @@ public class EnvoyLeaseTrackingTest {
 
         final Long result = envoyLeaseTracking.retrieve("t1", "e1").join();
 
-        assertEquals(new Long(2000), result);
+        assertEquals(Long.valueOf(2000), result);
     }
     @Test
     public void testLeases() {
-        Long leaseId = new Long(50);
+        @SuppressWarnings("WrapperTypeMayBePrimitive")
+        Long leaseId = 50L;
         String envoyInstance = "t1";
         
         when(etcd.getLeaseClient()).thenReturn(lease);

--- a/src/test/java/com/rackspace/salus/telemetry/etcd/services/EnvoyResourceManagementTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/etcd/services/EnvoyResourceManagementTest.java
@@ -22,23 +22,21 @@ import static com.rackspace.salus.telemetry.etcd.EtcdUtils.buildKey;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
-import com.coreos.jetcd.Client;
-import com.coreos.jetcd.data.KeyValue;
-import com.coreos.jetcd.lease.LeaseGrantResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.rackspace.salus.common.util.KeyHashing;
 import com.rackspace.salus.telemetry.model.ResourceInfo;
+import io.etcd.jetcd.Client;
+import io.etcd.jetcd.KeyValue;
 import io.etcd.jetcd.launcher.junit.EtcdClusterResource;
+import io.etcd.jetcd.lease.LeaseGrantResponse;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
-import java.net.URI;
 import java.net.UnknownHostException;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
-import java.util.stream.Collectors;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -58,10 +56,9 @@ public class EnvoyResourceManagementTest {
     public static class TestConfig {
         @Bean
         public Client getClient() {
-            final List<String> endpoints = etcd.cluster().getClientEndpoints().stream()
-                    .map(URI::toString)
-                    .collect(Collectors.toList());
-            return Client.builder().endpoints(endpoints).build();
+            return Client.builder().endpoints(
+                etcd.cluster().getClientEndpoints()
+            ).build();
         }
     }
 
@@ -145,7 +142,7 @@ public class EnvoyResourceManagementTest {
                             1, getResponse.getCount());
                     KeyValue storedData = getResponse.getKvs().get(0);
 
-                    String key = storedData.getKey().toStringUtf8();
+                    String key = storedData.getKey().toString(StandardCharsets.UTF_8);
                     ResourceInfo resourceInfo;
                     try {
                         resourceInfo = objectMapper.readValue(storedData.getValue().getBytes(), ResourceInfo.class);

--- a/src/test/java/com/rackspace/salus/telemetry/etcd/services/WorkAllocationPartitionServiceTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/etcd/services/WorkAllocationPartitionServiceTest.java
@@ -6,21 +6,19 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 
-import com.coreos.jetcd.Client;
-import com.coreos.jetcd.data.ByteSequence;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.rackspace.salus.common.util.KeyHashing;
 import com.rackspace.salus.telemetry.etcd.EtcdUtils;
 import com.rackspace.salus.telemetry.etcd.types.KeyRange;
 import com.rackspace.salus.telemetry.etcd.types.Keys;
 import com.rackspace.salus.telemetry.etcd.types.WorkAllocationRealm;
+import io.etcd.jetcd.ByteSequence;
+import io.etcd.jetcd.Client;
 import io.etcd.jetcd.launcher.junit.EtcdClusterResource;
 import java.io.IOException;
-import java.net.URI;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -46,10 +44,9 @@ public class WorkAllocationPartitionServiceTest {
 
   @Before
   public void setUp() throws Exception {
-    final List<String> endpoints = etcd.cluster().getClientEndpoints().stream()
-        .map(URI::toString)
-        .collect(Collectors.toList());
-    client = com.coreos.jetcd.Client.builder().endpoints(endpoints).build();
+    client = io.etcd.jetcd.Client.builder().endpoints(
+        etcd.cluster().getClientEndpoints()
+    ).build();
 
     service = new WorkAllocationPartitionService(
         client, new KeyHashing(), objectMapper, idGenerator);


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-474

# What

This is one of our two libraries that uses the jetcd library. Since they are still 0.x they took some liberties with the API switch from 0.0.2 to 0.3.0. (Already notice the change in semantic version position there.)

# How

- Use the new `io.etcd` group for dependencies. They now maintain the unit testing `jetcd-launcher`.
- Switch package references to `io.etcd.jetcd`
- The API leverages more of the asynchronous features of the etcd protocol, such as with the watcher. No longer need to do our own blocking `listen` call
- The string conversion calls don't make their own character set assumptions
- Some of the "data" types are now "top level" types in `io.etcd.jetcd`

## How to test

Existing unit tests