### PR TITLE
Upgrading to Spring Boot 2.1.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
         <!-- Import dependency management from Spring Boot -->
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
-        <version>2.1.2.RELEASE</version>
+        <version>2.1.6.RELEASE</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-361

# What

Our library and apps were on Spring Boot 2.1.2, but it's always good to stay on top of the latest release, which is 2.1.6.

## How to test

Unit tests and manual application startup.