### PR TITLE
Add an option to pass CA cert to etcd client configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,12 @@
       <artifactId>jetcd-core</artifactId>
       <version>${jetcd.version}</version>
     </dependency>
+    <dependency>
+      <!-- for etcd/grpc tls support -->
+      <groupId>io.netty</groupId>
+      <artifactId>netty-tcnative-boringssl-static</artifactId>
+      <version>2.0.25.Final</version>
+    </dependency>
 
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/rackspace/salus/telemetry/etcd/EtcdProperties.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/EtcdProperties.java
@@ -30,5 +30,23 @@ public class EtcdProperties {
      */
     String caCert;
 
+    /**
+     * If set, refers to a PEM file that contains the key material to enable mutual authentication
+     * with the etcd server.
+     */
+    String key;
+
+    /**
+     * If <code>key</code> is set, this can optionally be set to the path of a PEM file that contains
+     * the client certificate chain.
+     */
+    String keyCertChain;
+
+    /**
+     * If <code>key</code> is set, this can optionally be set if the key PEM is encrypted by a
+     * password.
+     */
+    String keyPassword;
+
     long envoyLeaseSec = 30;
 }

--- a/src/main/java/com/rackspace/salus/telemetry/etcd/EtcdProperties.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/EtcdProperties.java
@@ -1,19 +1,17 @@
 /*
- *    Copyright 2018 Rackspace US, Inc.
+ * Copyright 2019 Rackspace US, Inc.
  *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- *
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.rackspace.salus.telemetry.etcd;
@@ -27,5 +25,10 @@ import org.springframework.stereotype.Component;
 @Data
 public class EtcdProperties {
     String url = "http://localhost:2379";
+    /**
+     * If set, specifies the path to a CA PEM file to use for secured etcd connectivity.
+     */
+    String caCert;
+
     long envoyLeaseSec = 30;
 }

--- a/src/main/java/com/rackspace/salus/telemetry/etcd/TelemetryCoreEtcdModule.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/TelemetryCoreEtcdModule.java
@@ -19,6 +19,11 @@ package com.rackspace.salus.telemetry.etcd;
 import com.rackspace.salus.common.util.KeyHashing;
 import com.rackspace.salus.telemetry.etcd.services.EtcdHealthIndicator;
 import io.etcd.jetcd.Client;
+import io.etcd.jetcd.ClientBuilder;
+import io.grpc.netty.GrpcSslContexts;
+import java.io.File;
+import javax.net.ssl.SSLException;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.context.annotation.Bean;
@@ -28,22 +33,41 @@ import org.springframework.context.annotation.Import;
 @SpringBootConfiguration
 @ComponentScan
 @Import(KeyHashing.class)
+@Slf4j
 public class TelemetryCoreEtcdModule {
 
-    private final EtcdProperties properties;
+  private final EtcdProperties properties;
 
-    @Autowired
-    public TelemetryCoreEtcdModule(EtcdProperties etcdProperties) {
-        this.properties = etcdProperties;
+  @Autowired
+  public TelemetryCoreEtcdModule(EtcdProperties etcdProperties) {
+    this.properties = etcdProperties;
+  }
+
+  @Bean
+  public Client etcdClient() {
+    log.debug("Configuring etcd connectivity to {}", properties.getUrl());
+    final ClientBuilder builder = Client.builder()
+        .endpoints(properties.getUrl());
+
+    if (properties.getCaCert() != null) {
+      log.debug("Enabling SSL for etcd with CA cert at {}", properties.getCaCert());
+      final File caFile = new File(properties.getCaCert());
+      try {
+        builder.sslContext(GrpcSslContexts.forClient()
+            .trustManager(caFile)
+            .build()
+        );
+      } catch (SSLException e) {
+        throw new IllegalStateException(
+            String.format("Failed to setup SSL context for etcd given CA cert at %s", properties.getCaCert()), e);
+      }
     }
 
-    @Bean
-    public Client etcdClient() {
-        return Client.builder().endpoints(properties.getUrl()).build();
-    }
+    return builder.build();
+  }
 
-    @Bean
-    public EtcdHealthIndicator etcdHealthIndicator() {
-        return new EtcdHealthIndicator(etcdClient());
-    }
+  @Bean
+  public EtcdHealthIndicator etcdHealthIndicator() {
+    return new EtcdHealthIndicator(etcdClient());
+  }
 }


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-582

# What

Now that etcd is running in a cluster separate from the apps and Istio doesn't manage external connectivity, we need to allow for https configuration of the etcd clients.

# How

Since the jetcd docs lacked details, extrapolated the solution from the gRPC Java docs here

https://grpc.io/docs/guides/auth/#java

and here

https://github.com/grpc/grpc-java/blob/master/SECURITY.md#tls-with-netty-tcnative-on-boringssl

to see how to pass a CA cert file to the jetcd client builder.

The environment variable binding for the new property is `SALUS_ETCD_CACERT`.

## How to test

Will have to test on dev cluster.