### PR TITLE
Removing etcd key "envoysById" since it's not actually used

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/etcd/services/EnvoyLeaseTracking.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/services/EnvoyLeaseTracking.java
@@ -1,27 +1,22 @@
 /*
- *    Copyright 2018 Rackspace US, Inc.
+ * Copyright 2019 Rackspace US, Inc.
  *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- *
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.rackspace.salus.telemetry.etcd.services;
 
-import static com.rackspace.salus.telemetry.etcd.EtcdUtils.buildKey;
-
 import com.rackspace.salus.telemetry.etcd.EtcdProperties;
-import com.rackspace.salus.telemetry.etcd.types.Keys;
 import io.etcd.jetcd.Client;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -81,24 +76,6 @@ public class EnvoyLeaseTracking {
         else {
             log.warn("Did not have lease for envoyInstanceId={}", envoyInstanceId);
         }
-    }
-
-    public CompletableFuture<Long> retrieve(String tenantId, String envoyInstanceId) {
-        // NOTE: don't cache the resulting lease ID since this call might be used outside of the ambassador in which
-        // case the lifespan of the envoyLeases map is not managed.
-        return etcd.getKVClient().get(
-                buildKey(Keys.FMT_ENVOYS_BY_ID,
-                        tenantId, envoyInstanceId)
-        )
-                .thenApply(getResponse -> {
-                    if (getResponse.getCount() == 0) {
-                        log.warn("Unable to locate tenant={} envoyInstance={} in order to find lease",
-                                tenantId, envoyInstanceId);
-                        return 0L;
-                    } else {
-                        return getResponse.getKvs().get(0).getLease();
-                    }
-                });
     }
 
 }

--- a/src/main/java/com/rackspace/salus/telemetry/etcd/types/Keys.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/types/Keys.java
@@ -1,19 +1,17 @@
 /*
- *    Copyright 2018 Rackspace US, Inc.
+ * Copyright 2019 Rackspace US, Inc.
  *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- *
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.rackspace.salus.telemetry.etcd.types;
@@ -23,7 +21,6 @@ import java.util.regex.Pattern;
 
 public class Keys {
 
-    public static final String FMT_ENVOYS_BY_ID = "/tenants/{tenant}/envoysById/{envoyInstanceId}";
     public static final String FMT_IDENTIFIERS = "/tenants/{tenant}/identifiers/{resourceId}";
     public static final String FMT_RESOURCES_ACTIVE = "/resources/active/{md5OfTenantAndIdentifierValue}";
     public static final String FMT_WORKALLOC_REGISTRY = "/workAllocations/{realm}/registry/{partitionId}";

--- a/src/test/java/com/rackspace/salus/telemetry/etcd/services/EnvoyLeaseTrackingTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/etcd/services/EnvoyLeaseTrackingTest.java
@@ -22,13 +22,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.rackspace.salus.telemetry.etcd.EtcdProperties;
-import com.rackspace.salus.telemetry.etcd.EtcdUtils;
 import io.etcd.jetcd.Client;
 import io.etcd.jetcd.KV;
 import io.etcd.jetcd.Lease;
-import io.etcd.jetcd.api.KeyValue;
-import io.etcd.jetcd.api.RangeResponse;
-import io.etcd.jetcd.kv.GetResponse;
 import io.etcd.jetcd.lease.LeaseGrantResponse;
 import io.etcd.jetcd.lease.LeaseKeepAliveResponse;
 import io.etcd.jetcd.lease.LeaseRevokeResponse;
@@ -80,24 +76,6 @@ public class EnvoyLeaseTrackingTest {
         when(etcd.getKVClient()).thenReturn(kv);
     }
 
-    @Test
-    public void testRetrieve() {
-        when(kv.get(EtcdUtils.fromString("/tenants/t1/envoysById/e1")))
-            .thenReturn(
-                CompletableFuture.completedFuture(
-                    new GetResponse(RangeResponse.newBuilder()
-                        .setCount(1)
-                        .addKvs(KeyValue.newBuilder()
-                            .setLease(2000)
-                            .build())
-                        .build())
-                )
-            );
-
-        final Long result = envoyLeaseTracking.retrieve("t1", "e1").join();
-
-        assertEquals(Long.valueOf(2000), result);
-    }
     @Test
     public void testLeases() {
         @SuppressWarnings("WrapperTypeMayBePrimitive")


### PR DESCRIPTION
# Resolves

Prep for https://jira.rax.io/browse/SALUS-586

# What

In preparation for the issue above, I wanted to research where we still track envoys in etcd. This was the only potential key for that and turned out the only usage was in a unit test.

# How

Removed the dead code and unused key to avoid confusion.

## How to test

Existing tests