### PR TITLE
Bumped Spring Boot version to 2.2.4 and jacoco to 0.8.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2019 Rackspace US, Inc.
+  ~ Copyright 2020 Rackspace US, Inc.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <java.version>11</java.version>
     <jetcd.version>0.3.0</jetcd.version>
-    <jacoco-maven-plugin.version>0.8.2</jacoco-maven-plugin.version>
+    <jacoco-maven-plugin.version>0.8.5</jacoco-maven-plugin.version>
   </properties>
 
   <dependencies>
@@ -108,7 +108,7 @@
         <!-- Import dependency management from Spring Boot -->
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
-        <version>2.1.8.RELEASE</version>
+        <version>2.2.4.RELEASE</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
# Resolves

Part of https://jira.rax.io/browse/SALUS-738

# What

Bumped Spring Boot version to 2.2.4. No other changes (like the h2->mysql DB stuff) were needed in this module.

The jacoco upgrade was luckily an easy fix for a bizarre looking error I saw when running `mvn test`:

```
[DEBUG] Forking command line: /bin/sh -c cd /Users/geof0549/git/salus-telemetry-bundle/libs/etcd-adapter && /Library/Java/JavaVirtualMachines/jdk-13.0.1.jdk/Contents/Home/bin/java -javaagent:/Users/geof0549/.m2/repository/org/jacoco/org.jacoco.agent/0.8.2/org.jacoco.agent-0.8.2-runtime.jar=destfile=/Users/geof0549/git/salus-telemetry-bundle/libs/etcd-adapter/target/jacoco.exec org.apache.maven.surefire.booter.ForkedBooter /Users/geof0549/git/salus-telemetry-bundle/libs/etcd-adapter/target/surefire 2020-01-27T09-24-52_013-jvmRun1 surefire2433292549101996933tmp surefire_014036947465366232725tmp
--
[WARNING] Corrupted STDOUT by directly writing to native stream in forked JVM 1. See FAQ web page and the dump file /Users/geof0549/git/salus-telemetry-bundle/libs/etcd-adapter/target/surefire-reports/2020-01-27T09-24-52_013-jvmRun1.dumpstream
[DEBUG] FATAL ERROR in native method: processing of -javaagent failed, processJavaStart failed
```

My guess is that it is because I am running Java 13.0.1 and something got fixed in jacoco to support that.