### PR TITLE
Add salus-common dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,12 @@
       <artifactId>salus-telemetry-model</artifactId>
       <version>0.1.0-SNAPSHOT</version>
     </dependency>
+
+    <dependency>
+      <groupId>com.rackspace.salus</groupId>
+      <artifactId>salus-common</artifactId>
+      <version>0.1.0-SNAPSHOT</version>
+    </dependency>
     <dependency>
       <groupId>io.etcd</groupId>
       <artifactId>jetcd-core</artifactId>


### PR DESCRIPTION
Upcoming changes to salus-telemetry-model  will remove it's dependency on salus-common so we need to specifically include it in all services when needed.