### PR TITLE
toLowerCase EtcdUtils.buildKey

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/etcd/EtcdUtils.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/EtcdUtils.java
@@ -84,7 +84,7 @@ public class EtcdUtils {
         }
         matcher.appendTail(sb);
 
-        return fromString(sb.toString());
+        return fromString(sb.toString().toLowerCase());
     }
 
     /**

--- a/src/main/java/com/rackspace/salus/telemetry/etcd/types/ResolvedZone.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/types/ResolvedZone.java
@@ -41,12 +41,24 @@ public class ResolvedZone {
 
   private ResolvedZone(String zoneName) {
     this.tenantId = null; // indicates public
-    this.name = zoneName;
+    if(zoneName != null) {
+      this.name = zoneName.toLowerCase();
+    }else {
+      this.name = null;
+    }
   }
 
   private ResolvedZone(String zoneTenantId, String zoneName) {
-    this.tenantId = zoneTenantId;
-    this.name = zoneName;
+    if(zoneTenantId != null) {
+      this.tenantId = zoneTenantId.toLowerCase();
+    }else {
+      this.tenantId = null;
+    }
+    if(zoneName != null) {
+      this.name = zoneName.toLowerCase();
+    }else {
+      this.name = null;
+    }
   }
 
   public static ResolvedZone createPublicZone(String zoneName) {

--- a/src/main/java/com/rackspace/salus/telemetry/etcd/types/ResolvedZone.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/types/ResolvedZone.java
@@ -41,11 +41,8 @@ public class ResolvedZone {
 
   private ResolvedZone(String zoneName) {
     this.tenantId = null; // indicates public
-    if(zoneName != null) {
-      this.name = zoneName.toLowerCase();
-    }else {
-      this.name = null;
-    }
+    this.name = zoneName.toLowerCase();
+
   }
 
   private ResolvedZone(String zoneTenantId, String zoneName) {
@@ -54,11 +51,7 @@ public class ResolvedZone {
     }else {
       this.tenantId = null;
     }
-    if(zoneName != null) {
-      this.name = zoneName.toLowerCase();
-    }else {
-      this.name = null;
-    }
+    this.name = zoneName.toLowerCase();
   }
 
   public static ResolvedZone createPublicZone(String zoneName) {

--- a/src/main/java/com/rackspace/salus/telemetry/etcd/types/ResolvedZone.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/types/ResolvedZone.java
@@ -41,7 +41,7 @@ public class ResolvedZone {
 
   private ResolvedZone(String zoneName) {
     this.tenantId = null; // indicates public
-    this.name = zoneName.toLowerCase();
+    this.name = zoneName;
 
   }
 
@@ -51,7 +51,7 @@ public class ResolvedZone {
     }else {
       this.tenantId = null;
     }
-    this.name = zoneName.toLowerCase();
+    this.name = zoneName;
   }
 
   public static ResolvedZone createPublicZone(String zoneName) {

--- a/src/test/java/com/rackspace/salus/telemetry/etcd/EtcdUtilsTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/etcd/EtcdUtilsTest.java
@@ -40,7 +40,7 @@ public class EtcdUtilsTest {
             "t1", AgentType.FILEBEAT, "ais1"
         );
 
-        assertEquals("/tenants/t1/agentInstallSelectors/FILEBEAT/ais1", result.toString(
+        assertEquals("/tenants/t1/agentinstallselectors/filebeat/ais1", result.toString(
             StandardCharsets.UTF_8));
     }
 
@@ -48,7 +48,7 @@ public class EtcdUtilsTest {
     public void buildKey_noVars() {
         final ByteSequence result = EtcdUtils.buildKey("/agentInstalls");
 
-        assertEquals("/agentInstalls", result.toString(StandardCharsets.UTF_8));
+        assertEquals("/agentinstalls", result.toString(StandardCharsets.UTF_8));
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/src/test/java/com/rackspace/salus/telemetry/etcd/services/ZoneStorageTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/etcd/services/ZoneStorageTest.java
@@ -17,6 +17,7 @@
 package com.rackspace.salus.telemetry.etcd.services;
 
 import static com.rackspace.salus.telemetry.etcd.EtcdUtils.fromString;
+import static com.rackspace.salus.telemetry.etcd.types.Keys.FMT_ZONE_EXPIRING;
 import static com.rackspace.salus.telemetry.etcd.types.ResolvedZone.createPrivateZone;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.Matchers.equalTo;
@@ -29,6 +30,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
+import com.rackspace.salus.telemetry.etcd.EtcdUtils;
 import com.rackspace.salus.telemetry.etcd.types.EnvoyResourcePair;
 import com.rackspace.salus.telemetry.etcd.types.ResolvedZone;
 import io.etcd.jetcd.Client;
@@ -277,9 +279,8 @@ public class ZoneStorageTest {
     PutResponse response = zoneStorage.createExpiringEntry(zone, resourceId, envoyId, pollerTimeout).get();
 
     assertFalse(response.hasPrevKv());
-
     final GetResponse expiringResponse = client.getKVClient()
-        .get(fromString(String.format("/zones/expiring/t-1/%s/%s", zone.getName(), resourceId)))
+        .get(EtcdUtils.buildKey(FMT_ZONE_EXPIRING, "t-1", zone.getName(), resourceId))
         .join();
     assertThat(expiringResponse.getKvs(), hasSize(1));
 
@@ -303,8 +304,9 @@ public class ZoneStorageTest {
 
     zoneStorage.createExpiringEntry(zone, resourceId, envoyId, pollerTimeout).join();
 
+    ;
     GetResponse expiringResponse = client.getKVClient()
-        .get(fromString(String.format("/zones/expiring/t-1/%s/%s", zone.getName(), resourceId)))
+        .get(EtcdUtils.buildKey(FMT_ZONE_EXPIRING, "t-1", zone.getName(), resourceId))
         .join();
     assertThat(expiringResponse.getKvs(), hasSize(1));
 

--- a/src/test/java/com/rackspace/salus/telemetry/etcd/types/ResolvedZoneTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/etcd/types/ResolvedZoneTest.java
@@ -53,7 +53,7 @@ public class ResolvedZoneTest {
   public void getZoneNameForKey() {
     final ResolvedZone zone = createPublicZone("companyName/west");
 
-    assertThat(zone.getZoneNameForKey(), equalTo("companyname%2Fwest"));
+    assertThat(zone.getZoneNameForKey(), equalTo("companyName%2Fwest"));
   }
 
   @Test

--- a/src/test/java/com/rackspace/salus/telemetry/etcd/types/ResolvedZoneTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/etcd/types/ResolvedZoneTest.java
@@ -53,7 +53,7 @@ public class ResolvedZoneTest {
   public void getZoneNameForKey() {
     final ResolvedZone zone = createPublicZone("companyName/west");
 
-    assertThat(zone.getZoneNameForKey(), equalTo("companyName%2Fwest"));
+    assertThat(zone.getZoneNameForKey(), equalTo("companyname%2Fwest"));
   }
 
   @Test


### PR DESCRIPTION
I am opening this now so that people can comment some of their thoughts while I work on the zone-watcher tests. 

# Resolves

https://jira.rax.io/browse/SALUS-694

# What

The goal is to make the interaction with etcd case insensitive. Since etcd stores everything in a binary format and doesn't give any collation options there isn't a way to relax the etcd constraints on strings. It is case sensitive, period. The only way to get around this is to make all of our interactions with etcd either upper or lower case. 

# How

While building the key we toLowerCase the result to make sure that anytime anyone uses the buildKey utility function it always comes out the correct case.

## How to test

Run the unit tests

# Why

I had considered making everyones resourceId's the same case when we received them from the client but it is kind of bad to alter the customers data like that. 

# TODO

This library should be done. I need to finish updating tests in the zone-watcher and open the PR in monitor-management. 