### PR TITLE
Added limit on etcd client executor thread pool

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/etcd/EtcdProperties.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/EtcdProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,4 +49,9 @@ public class EtcdProperties {
     String keyPassword;
 
     long envoyLeaseSec = 30;
+
+    /**
+     * Configures the maximum size of the thread pool used for etcd client operations.
+     */
+    int maxExecutorThreads = 4;
 }

--- a/src/main/java/com/rackspace/salus/telemetry/etcd/TelemetryCoreEtcdModule.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/TelemetryCoreEtcdModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,10 @@ import io.etcd.jetcd.ClientBuilder;
 import io.grpc.netty.GrpcSslContexts;
 import io.netty.handler.ssl.SslContextBuilder;
 import java.io.File;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import javax.net.ssl.SSLException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -47,8 +51,13 @@ public class TelemetryCoreEtcdModule {
   @Bean
   public Client etcdClient() {
     log.debug("Configuring etcd connectivity to {}", properties.getUrl());
+    ExecutorService executorService = new ThreadPoolExecutor(1,
+        properties.getMaxExecutorThreads(),
+        60L, TimeUnit.SECONDS,
+        new SynchronousQueue<Runnable>());
     final ClientBuilder builder = Client.builder()
-        .endpoints(properties.getUrl());
+        .endpoints(properties.getUrl())
+        .executorService(executorService);
 
     if (properties.getCaCert() != null) {
       log.debug("Enabling SSL for etcd with CA cert at {}", properties.getCaCert());

--- a/src/main/java/com/rackspace/salus/telemetry/etcd/TelemetryCoreEtcdModule.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/TelemetryCoreEtcdModule.java
@@ -51,10 +51,13 @@ public class TelemetryCoreEtcdModule {
   @Bean
   public Client etcdClient() {
     log.debug("Configuring etcd connectivity to {}", properties.getUrl());
+    // Use a modification of java.util.concurrent.Executors.newCachedThreadPool()
+    // that bounds the pool size. The SynchronousQueue ensures there is back pressure
+    // on callers when the pool is fully occupied.
     ExecutorService executorService = new ThreadPoolExecutor(1,
         properties.getMaxExecutorThreads(),
         60L, TimeUnit.SECONDS,
-        new SynchronousQueue<Runnable>());
+        new SynchronousQueue<>());
     final ClientBuilder builder = Client.builder()
         .endpoints(properties.getUrl())
         .executorService(executorService);


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-873

# What

When using Envoy's stress-connections with 600 connections over 1 minute on local laptop, there were observed connection stability issues and the JDK Flight Recorder data included 321 observed threads, 213 of which had the prefix "grpc-default-executor".

# How

By setting a breakpoint on the top-level class involved in one of those threads I determined it was the jetcd client invocations that were allocating from a default thread pool executor. Being a default, there was no bound on the thread pool size.

This change instead uses a thread pool with one warm thread and a bounded number of threads. It also uses a SychronousQueue to put back pressure on callers, which works out fine since the callers are most often the Ambassador gRPC threads which are subject to the Netty worker pool constraints. After this change the observed "grpc-default-executor" threads were 15.

## How to test

Using Envoy with

```
stress-connections --config=envoy-config-provided.yml --debug --connection-count=600 --connections-delay=100ms --metrics-per-minute=1
```