### PR TITLE
Fixed back pressure behavior of executor for etcd client calls

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/etcd/EtcdProperties.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/EtcdProperties.java
@@ -54,4 +54,5 @@ public class EtcdProperties {
      * Configures the maximum size of the thread pool used for etcd client operations.
      */
     int maxExecutorThreads = 4;
+    int executorOfferTimeoutSec = 30;
 }


### PR DESCRIPTION
# What

In https://github.com/racker/salus-telemetry-etcd-adapter/pull/55 I misunderstood the behavior of the `SynchronousQueue` when the thread pool was at its limit. I thought it would use [the blocking put method](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/concurrent/SynchronousQueue.html#put(E)), but instead it uses [the non-blocking offer method](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/concurrent/SynchronousQueue.html#offer(E)).

As a result, when there were more than four concurrent etcd operations, the 5th would throw an exception:

```
2020-04-15 09:32:02.843 ERROR 2292 --- [   scheduling-1] o.s.s.s.TaskUtils$LoggingErrorHandler    : Unexpected error occurred in scheduled task

java.util.concurrent.RejectedExecutionException: java.util.concurrent.RejectedExecutionException: Task io.etcd.jetcd.Util$$Lambda$1186/0x0000000801210040@19d4687e rejected from java.util.concurrent.ThreadPoolExecutor@1debef9c[Running, pool size = 4, active threads = 4, queued tasks = 0, completed tasks = 1025]
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:500)
	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:481)
	at java.base/java.util.concurrent.ForkJoinTask.getThrowableException(ForkJoinTask.java:600)
	at java.base/java.util.concurrent.ForkJoinTask.reportException(ForkJoinTask.java:678)
	at java.base/java.util.concurrent.ForkJoinTask.invoke(ForkJoinTask.java:737)
	at java.base/java.util.concurrent.ConcurrentHashMap.forEachKey(ConcurrentHashMap.java:3863)
	at com.rackspace.salus.telemetry.ambassador.services.EnvoyRegistry.refreshEnvoys(EnvoyRegistry.java:273)
```

# How

They provide [a caller runs policy](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/concurrent/ThreadPoolExecutor.CallerRunsPolicy.html), but it felt better to keep the etcd call context consistently within an executor thread, so I'm using the blocking (but eventual timeout) offer call.

## How to test

Existing unit tests.

Also, I found the issue originally by stress testing with 60 connections, stopping the Envoy with its 60 connections, and observed the etcd lease processing logic in Ambassador.
