### PR TITLE
bump maven compiler plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -177,7 +177,7 @@
 
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.7.0</version>
+        <version>3.8.0</version>
         <configuration>
           <source>${java.version}</source>
           <target>${java.version}</target>


### PR DESCRIPTION
Some apps were failing to build on 3.7 so I'm bumping the plugin to 3.8 for everything.

The error was something along the lines of `source option 5 is no longer supported` and my search led me to find 3.8 solved this.