### PR TITLE
Added configuration for etcd rejected execution policy

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/etcd/EtcdProperties.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/EtcdProperties.java
@@ -54,5 +54,21 @@ public class EtcdProperties {
      * Configures the maximum size of the thread pool used for etcd client operations.
      */
     int maxExecutorThreads = 4;
+
+    public enum RejectedExecutionPolicy {
+        CALLER_RUNS,
+        BLOCKING_TIMEOUT
+    }
+
+    /**
+     * Specifies how attempts to call more than maxExecutorThreads number of concurrent etcd
+     * operations should be handled.
+     */
+    RejectedExecutionPolicy rejectedExecutionPolicy = RejectedExecutionPolicy.BLOCKING_TIMEOUT;
+
+    /**
+     * If rejectedExecutionPolicy is set to BLOCKING_TIMEOUT, this specifies the timeout of those
+     * blocking executor calls.
+     */
     int executorOfferTimeoutSec = 30;
 }

--- a/src/main/java/com/rackspace/salus/telemetry/etcd/services/EnvoyLeaseTracking.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/services/EnvoyLeaseTracking.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,6 +43,7 @@ public class EnvoyLeaseTracking {
     return etcd.getLeaseClient().grant(timeoutInSecs)
       .thenApply(leaseGrantResponse -> {
         final long leaseId = leaseGrantResponse.getID();
+        log.debug("Tracking lease={} for envoy={}", leaseId, leaseName);
         envoyLeases.put(leaseName, leaseId);
         return leaseId;
       });


### PR DESCRIPTION
# Resolves

For https://jira.rax.io/browse/SALUS-852

# What

I still couldn't decide what rejected execution policy will work best for us...

# How

...so made it a configurable property with the default being the blocking-with-timeout mode. In the process I cleaned up the config class to have a factory method each for the executor and rejection policy.

## How to test

With Ambassador and at least one Envoy connection, confirm that ready instruction is sent to Envoy.