### PR TITLE
Switched to a simple fixed thread pool executor with queuing

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/etcd/EtcdProperties.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/EtcdProperties.java
@@ -54,21 +54,4 @@ public class EtcdProperties {
      * Configures the maximum size of the thread pool used for etcd client operations.
      */
     int maxExecutorThreads = 4;
-
-    public enum RejectedExecutionPolicy {
-        CALLER_RUNS,
-        BLOCKING_TIMEOUT
-    }
-
-    /**
-     * Specifies how attempts to call more than maxExecutorThreads number of concurrent etcd
-     * operations should be handled.
-     */
-    RejectedExecutionPolicy rejectedExecutionPolicy = RejectedExecutionPolicy.BLOCKING_TIMEOUT;
-
-    /**
-     * If rejectedExecutionPolicy is set to BLOCKING_TIMEOUT, this specifies the timeout of those
-     * blocking executor calls.
-     */
-    int executorOfferTimeoutSec = 30;
 }

--- a/src/main/java/com/rackspace/salus/telemetry/etcd/TelemetryCoreEtcdModule.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/TelemetryCoreEtcdModule.java
@@ -22,14 +22,10 @@ import io.etcd.jetcd.Client;
 import io.etcd.jetcd.ClientBuilder;
 import io.grpc.netty.GrpcSslContexts;
 import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.util.concurrent.DefaultThreadFactory;
 import java.io.File;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.RejectedExecutionException;
-import java.util.concurrent.RejectedExecutionHandler;
-import java.util.concurrent.SynchronousQueue;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.ThreadPoolExecutor.CallerRunsPolicy;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.Executors;
 import javax.net.ssl.SSLException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -90,37 +86,11 @@ public class TelemetryCoreEtcdModule {
   }
 
   private ExecutorService etcdExecutorService() {
-    // Use a modification of java.util.concurrent.Executors.newCachedThreadPool()
-    // that bounds the pool size.
-    return new ThreadPoolExecutor(1,
-          properties.getMaxExecutorThreads(),
-          60L, TimeUnit.SECONDS,
-          // effectively disable queuing by using a direct-handoff
-          // NOTE: ThreadPoolExecutor uses the non-blocking offer method of the queue to determine availability
-          new SynchronousQueue<>(),
-          rejectedExecutionHandler()
-      );
-  }
-
-  private RejectedExecutionHandler rejectedExecutionHandler() {
-    final RejectedExecutionHandler handler;
-    switch (properties.getRejectedExecutionPolicy()) {
-      case BLOCKING_TIMEOUT:
-        handler = (r, executor) -> {
-          try {
-            if (!executor.getQueue().offer(r, properties.getExecutorOfferTimeoutSec(), TimeUnit.SECONDS)) {
-              throw new RejectedExecutionException("Timed out waiting to offer etcd call");
-            }
-          } catch (InterruptedException e) {
-            throw new RejectedExecutionException(e);
-          }
-        };
-        break;
-      case CALLER_RUNS:
-      default:
-        handler = new CallerRunsPolicy();
-    }
-    return handler;
+    // A queuing executor is needed since the chained, CompletableFuture based
+    // etcd operations can easily exhaust a limited thread pool and cause a deadlock
+    // at the point of executor submission
+    return Executors.newFixedThreadPool(properties.getMaxExecutorThreads(),
+        new DefaultThreadFactory("etcd"));
   }
 
   @Bean

--- a/src/main/java/com/rackspace/salus/telemetry/etcd/services/EnvoyLeaseTracking.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/services/EnvoyLeaseTracking.java
@@ -72,7 +72,10 @@ public class EnvoyLeaseTracking {
                     .thenAccept(leaseRevokeResponse -> {
                         log.debug("Revoked lease={} for envoy={}", leaseId, envoyInstanceId);
                     })
-                    .join();
+                    .exceptionally(throwable -> {
+                      log.warn("Failed to revoke lease={} for envoy={} message={}", leaseId, envoyInstanceId, throwable.getMessage());
+                      return null;
+                    });
         }
         else {
             log.warn("Did not have lease for envoyInstanceId={}", envoyInstanceId);


### PR DESCRIPTION
# What

With all the fancy thread executor setup and rejection policies in https://github.com/racker/salus-telemetry-etcd-adapter/pull/56 and https://github.com/racker/salus-telemetry-etcd-adapter/pull/58 it turned out that more than 4 concurrent etcd operations could get the Ambassador into a deadlocked state due to the CompletableFuture/chained call approach used extensively there. I didn't arrive at hard evidence of the deadlock, but I was able to consistently produce a "stuck" etcd thread executor when starting the envoy stress mode with 5 envoys all starting concurrently.

# How

Went back to basics and created a fixed thread pool which also includes a job queue when the pool (of 4 threads by default) is full.

## How to test

Tested locally with up to 10 current Envoy connections and then in perf cluster with 2000 Envoys.