### PR TITLE
Upgraded jetcd to 0.5.3 to upgrade grpc to 1.28.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <java.version>11</java.version>
-    <jetcd.version>0.3.0</jetcd.version>
+    <jetcd.version>0.5.3</jetcd.version>
     <jacoco-maven-plugin.version>0.8.5</jacoco-maven-plugin.version>
   </properties>
 
@@ -61,13 +61,19 @@
     <dependency>
       <groupId>io.etcd</groupId>
       <artifactId>jetcd-core</artifactId>
-      <version>${jetcd.version}</version>
     </dependency>
     <dependency>
       <!-- for etcd/grpc tls support -->
       <groupId>io.netty</groupId>
       <artifactId>netty-tcnative-boringssl-static</artifactId>
-      <version>2.0.25.Final</version>
+    </dependency>
+    <dependency>
+      <!--
+      Avoid dependency conflict with fluency-core by preferring jetcd's.
+      This is a managed dependency from jetcd-parent import below.
+      -->
+      <groupId>net.jodah</groupId>
+      <artifactId>failsafe</artifactId>
     </dependency>
 
     <dependency>
@@ -115,6 +121,13 @@
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
         <version>2.2.4.RELEASE</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>io.etcd</groupId>
+        <artifactId>jetcd-parent</artifactId>
+        <version>${jetcd.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/src/main/java/com/rackspace/salus/telemetry/etcd/workpart/WorkAllocator.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/workpart/WorkAllocator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,9 +31,7 @@ import static io.etcd.jetcd.op.Op.put;
 
 import io.etcd.jetcd.ByteSequence;
 import io.etcd.jetcd.Client;
-import io.etcd.jetcd.CloseableClient;
 import io.etcd.jetcd.KeyValue;
-import io.etcd.jetcd.Observers;
 import io.etcd.jetcd.Watch.Watcher;
 import io.etcd.jetcd.kv.DeleteResponse;
 import io.etcd.jetcd.kv.GetResponse;
@@ -48,6 +46,8 @@ import io.etcd.jetcd.options.GetOption.SortOrder;
 import io.etcd.jetcd.options.GetOption.SortTarget;
 import io.etcd.jetcd.options.PutOption;
 import io.etcd.jetcd.options.WatchOption;
+import io.etcd.jetcd.support.CloseableClient;
+import io.etcd.jetcd.support.Observers;
 import io.etcd.jetcd.watch.WatchEvent;
 import io.etcd.jetcd.watch.WatchResponse;
 import java.nio.charset.StandardCharsets;

--- a/src/test/java/com/rackspace/salus/telemetry/etcd/EtcdClusterResource.java
+++ b/src/test/java/com/rackspace/salus/telemetry/etcd/EtcdClusterResource.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2020 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.telemetry.etcd;
+
+import io.etcd.jetcd.launcher.EtcdCluster;
+import io.etcd.jetcd.launcher.EtcdClusterFactory;
+import java.net.URI;
+import java.util.List;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+/**
+ * This is a thin wrapper around {@link EtcdCluster} to enable junit rule/classrule support.
+ * It replaces the junit rule that used to be provided by jetcd-launcher.
+ */
+public class EtcdClusterResource implements TestRule {
+
+  private final String clusterName;
+  private final int nodes;
+  private final boolean ssl;
+  private EtcdCluster cluster;
+
+  public EtcdClusterResource(String clusterName, int nodes) {
+    this(clusterName, nodes, false);
+  }
+
+  public EtcdClusterResource(String clusterName, int nodes, boolean ssl) {
+    this.clusterName = clusterName;
+    this.nodes = nodes;
+    this.ssl = ssl;
+  }
+
+  @Override
+  public Statement apply(Statement base, Description description) {
+    return new Statement() {
+      @Override
+      public void evaluate() throws Throwable {
+        cluster = EtcdClusterFactory.buildCluster(clusterName, nodes, ssl);
+
+        cluster.start();
+        try {
+          base.evaluate();
+        } finally {
+          cluster.close();
+          cluster = null;
+        }
+      }
+    };
+  }
+
+  public List<URI> getClientEndpoints() {
+    return cluster.getClientEndpoints();
+  }
+}

--- a/src/test/java/com/rackspace/salus/telemetry/etcd/services/EnvoyResourceManagementTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/etcd/services/EnvoyResourceManagementTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,10 +22,10 @@ import static org.junit.Assert.assertNull;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.rackspace.salus.common.util.KeyHashing;
+import com.rackspace.salus.telemetry.etcd.EtcdClusterResource;
 import com.rackspace.salus.telemetry.model.ResourceInfo;
 import io.etcd.jetcd.Client;
 import io.etcd.jetcd.KeyValue;
-import io.etcd.jetcd.launcher.junit.EtcdClusterResource;
 import io.etcd.jetcd.lease.LeaseGrantResponse;
 import java.io.IOException;
 import java.net.InetAddress;
@@ -55,7 +55,7 @@ public class EnvoyResourceManagementTest {
         @Bean
         public Client getClient() {
             return Client.builder().endpoints(
-                etcd.cluster().getClientEndpoints()
+                etcd.getClientEndpoints()
             ).build();
         }
     }

--- a/src/test/java/com/rackspace/salus/telemetry/etcd/workpart/WorkAllocatorTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/etcd/workpart/WorkAllocatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,12 +26,12 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 
+import com.rackspace.salus.telemetry.etcd.EtcdClusterResource;
 import io.etcd.jetcd.ByteSequence;
 import io.etcd.jetcd.Client;
 import io.etcd.jetcd.KeyValue;
 import io.etcd.jetcd.kv.GetResponse;
 import io.etcd.jetcd.kv.TxnResponse;
-import io.etcd.jetcd.launcher.junit.EtcdClusterResource;
 import io.etcd.jetcd.op.Cmp;
 import io.etcd.jetcd.op.CmpTarget;
 import io.etcd.jetcd.op.Op;
@@ -96,7 +96,7 @@ public class WorkAllocatorTest {
     workerProperties.setPrefix("/" + testName.getMethodName() + "/");
 
     client = Client.builder().endpoints(
-        etcd.cluster().getClientEndpoints()
+        etcd.getClientEndpoints()
     ).build();
 
     workAllocatorsInTest = new ArrayList<>();


### PR DESCRIPTION
# Resolves

Part of https://jira.rax.io/browse/SALUS-852

# What

There was an issue where grpc server callbacks in ambassador were interfering with grpc client calls to etcd.

# How

Upgraded jetcd to 0.5.3 which itself brings us to grpc 1.28.1, which is much closer to the latest version.

A lot of methods in `EtcdUtils` would have needed to be tweaked due to jetcd introducing a namespace option; however, I noticed a lot of methods were no longer used so I simply removed them.

Similar to the spring-boot pom import technique for declaring managed dependencies, I did the same with jetcd-parent so that it simplifies the individual dependency declarations and guarantees they're aligned.

jetcd [has dropped support for junit 4](https://github.com/etcd-io/jetcd/issues/742#issuecomment-619726628), so `EtcdClusterResource.java` has been introduced as a simple junit 4 rule which wraps the new unit testing launcher code.

## How to test

Unit tests updated. Also tested manually with ambassador-envoy connections.