### PR TITLE
Disabled etcd health indicator by default since it seems to cause false-negatives

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/etcd/services/EtcdHealthIndicator.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/services/EtcdHealthIndicator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,15 +20,22 @@ import com.rackspace.salus.telemetry.etcd.EtcdUtils;
 import io.etcd.jetcd.Client;
 import io.etcd.jetcd.kv.GetResponse;
 import java.util.concurrent.ExecutionException;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.context.annotation.Profile;
 
 /**
  * Provides a Spring Boot actuator health indicator that determines the health of etcd by
  * performing a retrieval of an arbitrary key ("/"). Etcd is deemed healthy when that key
  * retrieval completes without an exception.
+ * <p>
+ *   This health indicator is enabled by activating the Spring profile "etcd-health-indicator"
+ * </p>
  */
+@Profile("etcd-health-indicator")
+@Slf4j
 public class EtcdHealthIndicator implements HealthIndicator {
 
   private final Client etcd;
@@ -45,6 +52,7 @@ public class EtcdHealthIndicator implements HealthIndicator {
           .get();
       return Health.up().build();
     } catch (InterruptedException | ExecutionException e) {
+      log.debug("etcd health indicator failed", e);
       return Health.down(e).build();
     }
   }


### PR DESCRIPTION
# What

In the staging cluster the presence monitor was failing readiness/liveness probes and only failure indication in logs was:

```
2020-07-20 19:48:41.693 DEBUG 1 --- [nio-7777-exec-8] o.s.web.servlet.DispatcherServlet        : Failed to complete request: org.apache.coyote.CloseNowException: Failed write
```

When attaching with a debugger and setting a breakpoint in `EtcdHealthIndicator.health` the `Health.down(e).build()` line was hit and the caught exception was simply `java.lang.InterruptedException`.

Application logs otherwise indicate successful interaction with etcd.

# How

Since I vaguely remember that health indicator causing weird issues before, I tagged it with a `@Profile` so that it would be excluded by default, but leaves the option to activate it later. I also added a debug log in the catch-block since inspecting the exception during probes is tricky to do before the pod gets restarted.