### PR TITLE
Shifted profile activation of EtcdHealthIndicator to bean declaration

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/etcd/TelemetryCoreEtcdModule.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/TelemetryCoreEtcdModule.java
@@ -33,6 +33,7 @@ import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Profile;
 
 @SpringBootConfiguration
 @ComponentScan
@@ -93,6 +94,7 @@ public class TelemetryCoreEtcdModule {
         new DefaultThreadFactory("etcd"));
   }
 
+  @Profile("etcd-health-indicator")
   @Bean
   public EtcdHealthIndicator etcdHealthIndicator() {
     return new EtcdHealthIndicator(etcdClient());

--- a/src/main/java/com/rackspace/salus/telemetry/etcd/services/EtcdHealthIndicator.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/services/EtcdHealthIndicator.java
@@ -24,7 +24,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.HealthIndicator;
-import org.springframework.context.annotation.Profile;
 
 /**
  * Provides a Spring Boot actuator health indicator that determines the health of etcd by
@@ -34,7 +33,6 @@ import org.springframework.context.annotation.Profile;
  *   This health indicator is enabled by activating the Spring profile "etcd-health-indicator"
  * </p>
  */
-@Profile("etcd-health-indicator")
 @Slf4j
 public class EtcdHealthIndicator implements HealthIndicator {
 


### PR DESCRIPTION
# What

I had made a mistake in https://github.com/racker/salus-telemetry-etcd-adapter/pull/61 with the `@Profile` declaration since I didn't realize the health indicator was declared via an `@Bean`.

# How

Moved the declaration to the `@Bean` itself.

## How to test

Tested (again) locally by running the app, accessing the `/actuator/health` endpoint and confirm the etcd indicator wasn't involved.

