### PR TITLE
Switched etcd client to use cached thread pool

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/etcd/TelemetryCoreEtcdModule.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/TelemetryCoreEtcdModule.java
@@ -87,10 +87,7 @@ public class TelemetryCoreEtcdModule {
   }
 
   private ExecutorService etcdExecutorService() {
-    // A queuing executor is needed since the chained, CompletableFuture based
-    // etcd operations can easily exhaust a limited thread pool and cause a deadlock
-    // at the point of executor submission
-    return Executors.newFixedThreadPool(properties.getMaxExecutorThreads(),
+    return Executors.newCachedThreadPool(
         new DefaultThreadFactory("etcd"));
   }
 


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-966

# What

Even with the deadlock removed in [the previous PR](https://github.com/racker/salus-telemetry-etcd-adapter/pull/63), the etcd client calls still hit a deadlock at the point shown below. It's because 

1. the etcd thread pool was configured to limit to 8 threads
2. 8 partitions in etcd caused the event handler code in work allocator to occupy those 8 threads
3. within `PresenceMonitorProcessor.start` several more etcd calls are made, which need to make use of the thread pool
4. no threads are available, yet at the deadlocked line (176), there is a `join()` blocking on the etcd call

```java
	at java.util.concurrent.locks.LockSupport.park(java.base@11.0.6/LockSupport.java:194)
	at java.util.concurrent.CompletableFuture$Signaller.block(java.base@11.0.6/CompletableFuture.java:1796)
	at java.util.concurrent.ForkJoinPool.managedBlock(java.base@11.0.6/ForkJoinPool.java:3128)
	at java.util.concurrent.CompletableFuture.waitingGet(java.base@11.0.6/CompletableFuture.java:1823)
	at java.util.concurrent.CompletableFuture.join(java.base@11.0.6/CompletableFuture.java:2043)
	at com.rackspace.salus.telemetry.presence_monitor.services.PresenceMonitorProcessor.start(PresenceMonitorProcessor.java:176)
	at com.rackspace.salus.telemetry.etcd.workpart.WorkAllocator.processGrabbedWork(WorkAllocator.java:612)
	at com.rackspace.salus.telemetry.etcd.workpart.WorkAllocator.lambda$grabWork$22(WorkAllocator.java:594)
	at com.rackspace.salus.telemetry.etcd.workpart.WorkAllocator$$Lambda$1108/0x0000000100883440.accept(Unknown Source)
```

# How

In hindsight, my previous attempts at limiting the stampeding herd of Envoys connecting to Ambassadors and the subsequent etcd client activity was solving things from the wrong direction. The swelling of the etcd client thread pool during that stampede misled me into thinking I should limit the etcd thread pool. Instead, I'll investigate semaphore based solutions to limit concurrent Envoy attachments and allow the etcd client threads to adapt as needed.

So, the etcd executor code comes full circle and we're back to a [simple, unbounded, caching thread pool](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/concurrent/Executors.html#newCachedThreadPool()).

# How to test

I ended up doing a dev build of the presence-monitor image, redeploying in staging with that, and confirming the deadlock issue is gone.