### PR TITLE
Restored etcd thread pool with limited core size, but with queuing

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/etcd/EtcdProperties.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/EtcdProperties.java
@@ -48,10 +48,9 @@ public class EtcdProperties {
      */
     String keyPassword;
 
-    long envoyLeaseSec = 30;
-
     /**
-     * Configures the maximum size of the thread pool used for etcd client operations.
+     * Configures the core size of the thread pool used for etcd client operations.
+     * Defaults to 2 x available processors.
      */
-    int maxExecutorThreads = 4;
+    int coreExecutorThreads = 2 * Runtime.getRuntime().availableProcessors();
 }

--- a/src/main/java/com/rackspace/salus/telemetry/etcd/TelemetryCoreEtcdModule.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/TelemetryCoreEtcdModule.java
@@ -28,6 +28,7 @@ import javax.net.ssl.SSLException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.task.TaskExecutorBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Import;
@@ -90,10 +91,11 @@ public class TelemetryCoreEtcdModule {
     int corePoolSize = properties.getCoreExecutorThreads();
     log.info("Configured etcd client executor pool corePoolSize={}", corePoolSize);
 
-    final ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
-    executor.setCorePoolSize(corePoolSize);
-    executor.setAllowCoreThreadTimeOut(true);
-    executor.setThreadNamePrefix("etcd");
+    final ThreadPoolTaskExecutor executor = new TaskExecutorBuilder()
+        .corePoolSize(corePoolSize)
+        .allowCoreThreadTimeOut(true)
+        .threadNamePrefix("etcd")
+        .build();
     executor.initialize();
 
     return new ExecutorServiceAdapter(executor);

--- a/src/main/java/com/rackspace/salus/telemetry/etcd/services/EnvoyLeaseTracking.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/services/EnvoyLeaseTracking.java
@@ -16,7 +16,6 @@
 
 package com.rackspace.salus.telemetry.etcd.services;
 
-import com.rackspace.salus.telemetry.etcd.EtcdProperties;
 import io.etcd.jetcd.Client;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -29,14 +28,12 @@ import org.springframework.stereotype.Service;
 public class EnvoyLeaseTracking {
 
     private final Client etcd;
-    private final EtcdProperties etcdProperties;
 
-    private ConcurrentHashMap<String, Long> envoyLeases = new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<String, Long> envoyLeases = new ConcurrentHashMap<>();
 
     @Autowired
-    public EnvoyLeaseTracking(Client etcd, EtcdProperties etcdProperties) {
+    public EnvoyLeaseTracking(Client etcd) {
         this.etcd = etcd;
-        this.etcdProperties = etcdProperties;
     }
 
   public CompletableFuture<Long> grant(String leaseName, long timeoutInSecs) {
@@ -48,10 +45,6 @@ public class EnvoyLeaseTracking {
         return leaseId;
       });
   }
-
-    public CompletableFuture<Long> grant(String envoyInstanceId) {
-        return grant(envoyInstanceId, etcdProperties.getEnvoyLeaseSec());
-    }
 
     public boolean keepAlive(String envoyInstanceId) {
         final Long leaseId = envoyLeases.get(envoyInstanceId);

--- a/src/test/java/com/rackspace/salus/telemetry/etcd/services/EnvoyLeaseTrackingTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/etcd/services/EnvoyLeaseTrackingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -85,7 +85,7 @@ public class EnvoyLeaseTrackingTest {
         when(etcd.getLeaseClient()).thenReturn(lease);
         when(lease.grant(anyLong())).thenReturn(CompletableFuture.completedFuture(grantResponse));
         when(grantResponse.getID()).thenReturn(leaseId);
-        final Long result = envoyLeaseTracking.grant(envoyInstance).join();
+        final Long result = envoyLeaseTracking.grant(envoyInstance, 60).join();
 
         assertEquals(leaseId, result);
 


### PR DESCRIPTION
# Part of

https://jira.rax.io/browse/SALUS-991

# What

A recent attempt to fix a thread-pool-deadlock issue in https://github.com/racker/salus-telemetry-etcd-adapter/pull/64 worked well for presence-monitor; however, ambassador's handling of a large number of concurrent envoy attachments degraded since the JVM process would get overwhelmed with an unbounded number of threads being created.

# How

Basically reverts https://github.com/racker/salus-telemetry-etcd-adapter/pull/64 but does things a bit better and cleaner:

- Use Spring's `ThreadPoolTaskExecutor` as a cleaner way to create a customizable thread pool executor
  - Focus on core pool size, which is intuitively the parameter that primarily drives the number of threads to use
  - ...but use `setAllowCoreThreadTimeOut` so that the number of core threads can scale back when the system is idle
- Instead of configuring envoy lease duration at a part of etcd-adapter, have that be configured in ambassador and passed from there (PR coming up)
- Rather than hard code `coreExecutorThreads` derive the default from the reported number of processors (aka vCPUs aka processor cores)

## How to test

Unit tests work as before and stress testing with 5 envoys running stress-mode with 1000 connections each.