### PR TITLE
Removing zone binding counts from etcd and using BoundMonitor table instead

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/etcd/types/Keys.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/types/Keys.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ public class Keys {
     public static final String FMT_RESOURCE_ACTIVE_BY_HASH = "/resources/active/{md5OfTenantAndIdentifierValue}";
 
     /**
-     * Value is count of bound monitors, leading zero padded to 10 digits
+     * Value is not used, only the key existence is significant
      */
     public static final String FMT_ZONE_ACTIVE = "/zones/active/{tenant}/{zoneName}/{resourceId}";
     public static final Pattern PTN_ZONE_ACTIVE = EtcdUtils.patternFromFormat(FMT_ZONE_ACTIVE);

--- a/src/main/java/com/rackspace/salus/telemetry/etcd/types/ResolvedZone.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/types/ResolvedZone.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import com.rackspace.salus.telemetry.etcd.EtcdUtils;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
+import org.springframework.util.Assert;
 
 /**
  * This class is both a data holder and utility for resolving given zone IDs and optionally
@@ -52,6 +53,25 @@ public class ResolvedZone {
       this.tenantId = null;
     }
     this.name = zoneName;
+  }
+
+  /**
+   * Convenience builder that resolves to a public or private zone based upon the
+   * prefix of the given <code>zoneName</code>
+   * @param zoneTenantId For private zones, the tenant owning the zone. For public, zones
+   * this is ignored.
+   * @param zoneName The zone name, where public zones are prefixed with {@value PUBLIC_PREFIX}
+   * @return a resolved public or private zone
+   */
+  public static ResolvedZone resolveZone(String zoneTenantId, String zoneName) {
+    if (zoneName.startsWith(PUBLIC_PREFIX)) {
+      return createPublicZone(zoneName);
+    }
+    else {
+      Assert.notNull(zoneTenantId, "Private zones require a tenantId");
+      return createPrivateZone(zoneTenantId, zoneName);
+    }
+
   }
 
   public static ResolvedZone createPublicZone(String zoneName) {


### PR DESCRIPTION
# Part of

https://jira.rax.io/browse/SALUS-358

# What

Rather than use a brittle, DIY counter in etcd, we'll instead use etcd to simply retrieve a list of the active poller's per remote monitoring zone and use the `BoundMonitor` table as the single source of truth for bindings per envoy-poller.

The motivation to make this change was observing my local system having troubles binding a new monitor to the 1000 resources I had left over from envoy-ambassador stress testing. The `ZoneStorage` code was getting itself into a tight loop of operations like the following with numerous collisions trying to increment the binding count:

```
2020-08-28 13:22:10.821 DEBUG [salus-telemetry-monitor-management,,,] 78771 --- [         etcd22] c.r.s.t.etcd.services.ZoneStorage        : Putting new bound count=894 for resource=development:0 in zone=ResolvedZone(name=dev, tenantId=aaaaaa)
2020-08-28 13:22:10.821 DEBUG [salus-telemetry-monitor-management,,,] 78771 --- [         etcd27] c.r.s.t.etcd.services.ZoneStorage        : Changing bound count of resource=development:0 in zone=ResolvedZone(name=dev, tenantId=aaaaaa) by amount=-1
2020-08-28 13:22:10.827 DEBUG [salus-telemetry-monitor-management,,,] 78771 --- [         etcd30] c.r.s.t.etcd.services.ZoneStorage        : Re-trying incrementing bound count of resource=development:0 in zone=ResolvedZone(name=dev, tenantId=aaaaaa) due to collision
```

# How

Ripped out a bunch of code that had to do with the binding count stored at the envoy-poller-resource key under the `/zones/active/` path. The key itself still needs to remain since that is used to observe and track the existence of an envoy-poller currently attached into zone.

Added a new method to get that list of envoy-poller resourceIds active in a zone. Also added a method to get a mapping of poller resourceId's to envoyId's. (We had the reverse method already, so the new one just flips the result of that one.)

## How to test

Added new unit tests for the newly added methods. Ripped out all the unneeded ones.