### PR TITLE
Fix tests by using latest testcontainers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,11 @@
       <version>${jetcd.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers</artifactId>
+      <version>1.15.0-rc2</version>
+    </dependency>
 
     <dependency>
       <groupId>org.projectlombok</groupId>


### PR DESCRIPTION
Tests fail after a Docker for Desktop update.

Fix them by upgrading to 1.15.0-rc2 to pick up testcontainers/testcontainers-java#3159