### PR TITLE
Added method to support detached but pending timeout pollers

### DIFF
--- a/src/main/java/com/rackspace/salus/telemetry/etcd/services/ZoneStorage.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/services/ZoneStorage.java
@@ -51,6 +51,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import javax.annotation.PreDestroy;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -274,7 +275,11 @@ public class ZoneStorage {
   }
 
   public CompletableFuture<List<String>> getExpiredPollerResourceIdsInZone(ResolvedZone zone) {
-    final ByteSequence prefix = buildKey(FMT_ZONE_EXPIRING_IN_ZONE, zone.getTenantForKey(),
+    StringBuilder key = new StringBuilder(FMT_ZONE_EXPIRING_IN_ZONE);
+    if(StringUtils.isNotBlank(zone.getName())) {
+      key.append("/");
+    }
+    final ByteSequence prefix = buildKey(key.toString(), zone.getTenantForKey(),
         zone.getZoneNameForKey());
     return getPollerResourceIdsInZone(prefix);
   }

--- a/src/main/java/com/rackspace/salus/telemetry/etcd/services/ZoneStorage.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/services/ZoneStorage.java
@@ -19,7 +19,9 @@ package com.rackspace.salus.telemetry.etcd.services;
 import static com.rackspace.salus.telemetry.etcd.EtcdUtils.buildKey;
 import static com.rackspace.salus.telemetry.etcd.EtcdUtils.fromString;
 import static com.rackspace.salus.telemetry.etcd.types.Keys.FMT_ZONE_ACTIVE;
+import static com.rackspace.salus.telemetry.etcd.types.Keys.FMT_ZONE_ACTIVE_IN_ZONE;
 import static com.rackspace.salus.telemetry.etcd.types.Keys.FMT_ZONE_EXPECTED;
+import static com.rackspace.salus.telemetry.etcd.types.Keys.FMT_ZONE_EXPECTED_IN_ZONE;
 import static com.rackspace.salus.telemetry.etcd.types.Keys.FMT_ZONE_EXPIRING;
 import static com.rackspace.salus.telemetry.etcd.types.Keys.FMT_ZONE_EXPIRING_IN_ZONE;
 
@@ -104,7 +106,7 @@ public class ZoneStorage {
 
   public CompletableFuture<List<String>> getActivePollerResourceIdsInZone(ResolvedZone zone) {
     final ByteSequence prefix =
-        buildKey(FMT_ZONE_ACTIVE, zone.getTenantForKey(), zone.getZoneNameForKey(), "");
+        buildKey(FMT_ZONE_ACTIVE_IN_ZONE, zone.getTenantForKey(), zone.getZoneNameForKey());
 
     return getPollerResourceIdsInZone(prefix);
   }
@@ -130,7 +132,7 @@ public class ZoneStorage {
   public CompletableFuture<Map<String, String>> getEnvoyIdToResourceIdMap(
       ResolvedZone zone) {
     final ByteSequence prefix =
-        buildKey(FMT_ZONE_EXPECTED, zone.getTenantForKey(), zone.getZoneNameForKey(), "");
+        buildKey(FMT_ZONE_EXPECTED_IN_ZONE, zone.getTenantForKey(), zone.getZoneNameForKey());
 
     return etcd.getKVClient().get(
         prefix,
@@ -275,12 +277,9 @@ public class ZoneStorage {
   }
 
   public CompletableFuture<List<String>> getExpiredPollerResourceIdsInZone(ResolvedZone zone) {
-    StringBuilder key = new StringBuilder(FMT_ZONE_EXPIRING_IN_ZONE);
-    if(StringUtils.isNotBlank(zone.getName())) {
-      key.append("/");
-    }
-    final ByteSequence prefix = buildKey(key.toString(), zone.getTenantForKey(),
-        zone.getZoneNameForKey());
+    final ByteSequence prefix =
+        buildKey(FMT_ZONE_EXPIRING_IN_ZONE, zone.getTenantForKey(), zone.getZoneNameForKey());
+
     return getPollerResourceIdsInZone(prefix);
   }
 

--- a/src/main/java/com/rackspace/salus/telemetry/etcd/services/ZoneStorage.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/services/ZoneStorage.java
@@ -276,7 +276,7 @@ public class ZoneStorage {
     return etcd.getWatchClient();
   }
 
-  public CompletableFuture<List<String>> getExpiredPollerResourceIdsInZone(ResolvedZone zone) {
+  public CompletableFuture<List<String>> getExpiringPollerResourceIdsInZone(ResolvedZone zone) {
     final ByteSequence prefix =
         buildKey(FMT_ZONE_EXPIRING_IN_ZONE, zone.getTenantForKey(), zone.getZoneNameForKey());
 

--- a/src/main/java/com/rackspace/salus/telemetry/etcd/types/Keys.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/types/Keys.java
@@ -39,7 +39,7 @@ public class Keys {
      */
     public static final String FMT_ZONE_EXPIRING = "/zones/expiring/{tenant}/{zoneName}/{resourceId}";
     public static final Pattern PTN_ZONE_EXPIRING = EtcdUtils.patternFromFormat(FMT_ZONE_EXPIRING);
-    public static final String FMT_ZONE_EXPIRING_IN_ZONE = "/zones/expiring/{tenant}/{zoneName}/";
+    public static final String FMT_ZONE_EXPIRING_IN_ZONE = "/zones/expiring/{tenant}/{zoneName}";
 
     public static final String PREFIX_ZONE_EXPECTED = "/zones/expected";
     public static final String PREFIX_ZONE_ACTIVE = "/zones/active";

--- a/src/main/java/com/rackspace/salus/telemetry/etcd/types/Keys.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/types/Keys.java
@@ -39,6 +39,7 @@ public class Keys {
      */
     public static final String FMT_ZONE_EXPIRING = "/zones/expiring/{tenant}/{zoneName}/{resourceId}";
     public static final Pattern PTN_ZONE_EXPIRING = EtcdUtils.patternFromFormat(FMT_ZONE_EXPIRING);
+    public static final String FMT_ZONE_EXPIRING_IN_ZONE = "/zones/expiring/{tenant}/{zoneName}/";
 
     public static final String PREFIX_ZONE_EXPECTED = "/zones/expected";
     public static final String PREFIX_ZONE_ACTIVE = "/zones/active";

--- a/src/main/java/com/rackspace/salus/telemetry/etcd/types/Keys.java
+++ b/src/main/java/com/rackspace/salus/telemetry/etcd/types/Keys.java
@@ -29,17 +29,19 @@ public class Keys {
      */
     public static final String FMT_ZONE_ACTIVE = "/zones/active/{tenant}/{zoneName}/{resourceId}";
     public static final Pattern PTN_ZONE_ACTIVE = EtcdUtils.patternFromFormat(FMT_ZONE_ACTIVE);
+    public static final String FMT_ZONE_ACTIVE_IN_ZONE = "/zones/active/{tenant}/{zoneName}/";
     /**
      * Value is latest attached envoy ID
      */
     public static final String FMT_ZONE_EXPECTED = "/zones/expected/{tenant}/{zoneName}/{resourceId}";
+    public static final String FMT_ZONE_EXPECTED_IN_ZONE = "/zones/expected/{tenant}/{zoneName}/";
     public static final Pattern PTN_ZONE_EXPECTED = EtcdUtils.patternFromFormat(FMT_ZONE_EXPECTED);
     /**
      * Value is latest attached envoy ID
      */
     public static final String FMT_ZONE_EXPIRING = "/zones/expiring/{tenant}/{zoneName}/{resourceId}";
     public static final Pattern PTN_ZONE_EXPIRING = EtcdUtils.patternFromFormat(FMT_ZONE_EXPIRING);
-    public static final String FMT_ZONE_EXPIRING_IN_ZONE = "/zones/expiring/{tenant}/{zoneName}";
+    public static final String FMT_ZONE_EXPIRING_IN_ZONE = "/zones/expiring/{tenant}/{zoneName}/";
 
     public static final String PREFIX_ZONE_EXPECTED = "/zones/expected";
     public static final String PREFIX_ZONE_ACTIVE = "/zones/active";

--- a/src/test/java/com/rackspace/salus/telemetry/etcd/services/ZoneStorageTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/etcd/services/ZoneStorageTest.java
@@ -306,7 +306,7 @@ public class ZoneStorageTest {
   }
 
   @Test
-  public void testGetExpiredPollerResourceIdsInZone() throws InterruptedException {
+  public void testGetExpiringPollerResourceIdsInZone() throws InterruptedException {
     ResolvedZone zone = createPrivateZone("t-1", RandomStringUtils.randomAlphabetic(10));
     final String resourceId = RandomStringUtils.randomAlphabetic(10);
     final String envoyId = RandomStringUtils.randomAlphabetic(10);
@@ -317,21 +317,21 @@ public class ZoneStorageTest {
         .thenReturn(CompletableFuture.completedFuture(leaseId));
 
     zoneStorage.createExpiringEntry(zone, resourceId, envoyId, pollerTimeout).join();
-    List<String> envoyList = zoneStorage.getExpiredPollerResourceIdsInZone(zone).join();
+    List<String> envoyList = zoneStorage.getExpiringPollerResourceIdsInZone(zone).join();
 
     assertThat(envoyList, hasSize(1));
     assertEquals(envoyList.get(0), resourceId.toLowerCase());
 
     zone = createPublicZone(RandomStringUtils.randomAlphabetic(10));
     zoneStorage.createExpiringEntry(zone, resourceId, envoyId, pollerTimeout).join();
-    List<String> envoyListPublicZone = zoneStorage.getExpiredPollerResourceIdsInZone(zone).join();
+    List<String> envoyListPublicZone = zoneStorage.getExpiringPollerResourceIdsInZone(zone).join();
 
     assertThat(envoyListPublicZone, hasSize(1));
     assertEquals(envoyListPublicZone.get(0), resourceId.toLowerCase());
   }
 
   @Test
-  public void testGetExpiredPollerResourceIds_PerTenant_AllZones() {
+  public void testGetExpiringPollerResourceIds_PerTenant_AllZones() {
     ResolvedZone zone1 = createPrivateZone("t-1", RandomStringUtils.randomAlphabetic(10));
     ResolvedZone zone2 = createPrivateZone("t-1", RandomStringUtils.randomAlphabetic(10));
     final String resourceId1 = RandomStringUtils.randomAlphabetic(10);
@@ -346,7 +346,7 @@ public class ZoneStorageTest {
     zoneStorage.createExpiringEntry(zone1, resourceId1, envoyId, pollerTimeout).join();
     zoneStorage.createExpiringEntry(zone2, resourceId2, envoyId, pollerTimeout).join();
     ResolvedZone zoneAllTenants = createPrivateZone("t-1", "");
-    List<String> envoyList = zoneStorage.getExpiredPollerResourceIdsInZone(zoneAllTenants).join();
+    List<String> envoyList = zoneStorage.getExpiringPollerResourceIdsInZone(zoneAllTenants).join();
 
     assertThat(envoyList, hasSize(2));
     assertThat(envoyList, containsInAnyOrder(resourceId1.toLowerCase(), resourceId2.toLowerCase()));

--- a/src/test/java/com/rackspace/salus/telemetry/etcd/services/ZoneStorageTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/etcd/services/ZoneStorageTest.java
@@ -329,26 +329,4 @@ public class ZoneStorageTest {
     assertThat(envoyListPublicZone, hasSize(1));
     assertEquals(envoyListPublicZone.get(0), resourceId.toLowerCase());
   }
-
-  @Test
-  public void testGetExpiringPollerResourceIds_PerTenant_AllZones() {
-    ResolvedZone zone1 = createPrivateZone("t-1", RandomStringUtils.randomAlphabetic(10));
-    ResolvedZone zone2 = createPrivateZone("t-1", RandomStringUtils.randomAlphabetic(10));
-    final String resourceId1 = RandomStringUtils.randomAlphabetic(10);
-    final String resourceId2 = RandomStringUtils.randomAlphabetic(10);
-    final String envoyId = RandomStringUtils.randomAlphabetic(10);
-    final long pollerTimeout = 1000;
-    final long leaseId = grantLease(pollerTimeout);
-
-    when(envoyLeaseTracking.grant(anyString(), anyLong()))
-        .thenReturn(CompletableFuture.completedFuture(leaseId));
-
-    zoneStorage.createExpiringEntry(zone1, resourceId1, envoyId, pollerTimeout).join();
-    zoneStorage.createExpiringEntry(zone2, resourceId2, envoyId, pollerTimeout).join();
-    ResolvedZone zoneAllTenants = createPrivateZone("t-1", "");
-    List<String> envoyList = zoneStorage.getExpiringPollerResourceIdsInZone(zoneAllTenants).join();
-
-    assertThat(envoyList, hasSize(2));
-    assertThat(envoyList, containsInAnyOrder(resourceId1.toLowerCase(), resourceId2.toLowerCase()));
-  }
 }

--- a/src/test/java/com/rackspace/salus/telemetry/etcd/services/ZoneStorageTest.java
+++ b/src/test/java/com/rackspace/salus/telemetry/etcd/services/ZoneStorageTest.java
@@ -19,12 +19,14 @@ package com.rackspace.salus.telemetry.etcd.services;
 import static com.rackspace.salus.telemetry.etcd.EtcdUtils.fromString;
 import static com.rackspace.salus.telemetry.etcd.types.Keys.FMT_ZONE_EXPIRING;
 import static com.rackspace.salus.telemetry.etcd.types.ResolvedZone.createPrivateZone;
+import static com.rackspace.salus.telemetry.etcd.types.ResolvedZone.createPublicZone;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -43,6 +45,7 @@ import io.etcd.jetcd.options.LeaseOption;
 import io.etcd.jetcd.watch.WatchEvent;
 import io.etcd.jetcd.watch.WatchEvent.EventType;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -300,5 +303,30 @@ public class ZoneStorageTest {
   private void revokeLease(long leaseId) {
     client.getLeaseClient().revoke(leaseId).join();
 
+  }
+
+  @Test
+  public void testGetExpiredPollerResourceIdsInZone() throws InterruptedException {
+    ResolvedZone zone = createPrivateZone("t-1", RandomStringUtils.randomAlphabetic(10));
+    final String resourceId = RandomStringUtils.randomAlphabetic(10);
+    final String envoyId = RandomStringUtils.randomAlphabetic(10);
+    final long pollerTimeout = 1000;
+    final long leaseId = grantLease(pollerTimeout);
+
+    when(envoyLeaseTracking.grant(anyString(), anyLong()))
+        .thenReturn(CompletableFuture.completedFuture(leaseId));
+
+    zoneStorage.createExpiringEntry(zone, resourceId, envoyId, pollerTimeout).join();
+    List<String> envoyList = zoneStorage.getExpiredPollerResourceIdsInZone(zone).join();
+
+    assertThat(envoyList, hasSize(1));
+    assertEquals(envoyList.get(0), resourceId.toLowerCase());
+
+    zone = createPublicZone(RandomStringUtils.randomAlphabetic(10));
+    zoneStorage.createExpiringEntry(zone, resourceId, envoyId, pollerTimeout).join();
+    List<String> envoyListPublicZone = zoneStorage.getExpiredPollerResourceIdsInZone(zone).join();
+
+    assertThat(envoyListPublicZone, hasSize(1));
+    assertEquals(envoyListPublicZone.get(0), resourceId.toLowerCase());
   }
 }


### PR DESCRIPTION
# Resolves
https://jira.rax.io/browse/SALUS-992

# What
Added method to support detached but pending timeout pollers

# How
Created a method in ZoneStorage to get pollers which are detached but pending timeout.

## How to test
This can be tested via unit test cases.